### PR TITLE
Argo-CD exclusions for Cilium

### DIFF
--- a/gitops/argocd/bootstrap/argo-cd/values.yaml
+++ b/gitops/argocd/bootstrap/argo-cd/values.yaml
@@ -115,6 +115,14 @@ argo-cd:
         end
         return hs
 
+      resource.exclusions: |
+        - apiGroups:
+            - cilium.io
+          kinds:
+            - CiliumIdentity
+          clusters:
+            - "*"
+
     params:
       # -- Number of application status processors
       controller.status.processors: 20


### PR DESCRIPTION
See: https://docs.cilium.io/en/stable/configuration/argocd-issues/#argo-cd-deletes-customresourcedefinitions