### PR TITLE
Remove CRDs for kube-prometheus-chart chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ helm-argo-template: guard-CHART guard-CLOUD guard-ENV ## Template Helm chart (CH
 		&& export NAMESPACE=$$(basename $$(dirname $(CHART))) \
 		&& rm -fr charts Chart.lock \
 		&& helm dependency build >&2 \
-		&& helm template portefaix . --debug --namespace $${NAMESPACE} -f ./values.yaml -f "./values-$(CLOUD)-$(ENV).yaml" --api-versions=monitoring.coreos.com/v1 \
+		&& helm template portefaix . --debug --include-crds --namespace $${NAMESPACE} -f ./values.yaml -f "./values-$(CLOUD)-$(ENV).yaml" --api-versions=monitoring.coreos.com/v1 \
 		&& rm -fr Chart.lock charts \
 		&& popd > /dev/null
 

--- a/gitops/argocd/charts/monitoring/kube-prometheus-stack/values.yaml
+++ b/gitops/argocd/charts/monitoring/kube-prometheus-stack/values.yaml
@@ -35,6 +35,9 @@ kube-prometheus-stack:
   commonLabels:
     portefaix.xyz/version: v0.46.0
 
+  crds:
+    enabled: false
+
   defaultRules:
     create: true
     labels:


### PR DESCRIPTION
Bootstrap use the `prometheus-operator-crds` chart.