### PR TITLE
WebAssembly: setup WasmCloud

### DIFF
--- a/gitops/argocd/charts/messaging/nats/Chart.yaml
+++ b/gitops/argocd/charts/messaging/nats/Chart.yaml
@@ -10,4 +10,4 @@ appVersion: 1.0.0
 dependencies:
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts
-  version: 1.1.11
+  version: 1.2.10

--- a/gitops/argocd/charts/messaging/nats/values-talos-homelab.yaml
+++ b/gitops/argocd/charts/messaging/nats/values-talos-homelab.yaml
@@ -4,9 +4,6 @@
 ---
 nats:
   config:
-    cluster:
-      size: 3
-
     jetstream:
       fileStore:
         pvc:

--- a/gitops/argocd/charts/messaging/nats/values.yaml
+++ b/gitops/argocd/charts/messaging/nats/values.yaml
@@ -7,12 +7,18 @@ nats:
     labels:
       portefaix.xyz/version: v0.54.0
 
-  config:
-    cluster:
-      enabled: true
-
-    jetstream:
-      enabled: true
+  cluster:
+    enabled: true
+    replicas: 3
+  leafnodes:
+    enabled: true
+  websocket:
+    enabled: true
+    port: 4223
+  jetstream:
+    enabled: true
+    merge:
+      domain: default
 
   promExporter:
     enabled: true

--- a/gitops/argocd/charts/messaging/nats/values.yaml
+++ b/gitops/argocd/charts/messaging/nats/values.yaml
@@ -7,18 +7,19 @@ nats:
     labels:
       portefaix.xyz/version: v0.54.0
 
-  cluster:
-    enabled: true
-    replicas: 3
-  leafnodes:
-    enabled: true
-  websocket:
-    enabled: true
-    port: 4223
-  jetstream:
-    enabled: true
-    merge:
-      domain: default
+  config:
+    cluster:
+      enabled: true
+      replicas: 3
+    leafnodes:
+      enabled: true
+    websocket:
+      enabled: true
+      port: 4223
+    jetstream:
+      enabled: true
+      merge:
+        domain: default
 
   promExporter:
     enabled: true

--- a/gitops/argocd/charts/wasm/wasmcloud/Chart.yaml
+++ b/gitops/argocd/charts/wasm/wasmcloud/Chart.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: v2
+type: application
+name: wasmcloud
+version: 1.0.0
+appVersion: 1.0.0
+dependencies:
+- name: wadm
+  version: 0.2.7
+  repository: oci://ghcr.io/wasmcloud/charts
+- name: wasmcloud-operator
+  version: 0.1.5
+  repository: oci://ghcr.io/wasmcloud/charts

--- a/gitops/argocd/charts/wasm/wasmcloud/templates/http-hello-world-go.yaml
+++ b/gitops/argocd/charts/wasm/wasmcloud/templates/http-hello-world-go.yaml
@@ -34,6 +34,14 @@ spec:
       type: capability
       properties:
         image: ghcr.io/wasmcloud/http-server:0.26.0
+        ## To configure OTEL integration for this provider specifically, uncomment the lines below
+        config:
+          - name: otel
+            properties:
+              otel_exporter_otlp_endpoint: "{{ .Values.wasmApps.opentelemetry.gateway.endpoint }}"
+              # otel_exporter_otlp_traces_endpoint: "http://traces-backend/v1/traces"
+              # otel_exporter_otlp_metrics_endpoint: "http://metrics-backend/v1/metrics"
+              # otel_exporter_otlp_logs_endpoint: "http://logs-backend/v1/logs"
       traits:
         # Link the httpserver to the component, and configure the HTTP server
         # to listen on port 8000 for incoming requests

--- a/gitops/argocd/charts/wasm/wasmcloud/templates/http-hello-world-go.yaml
+++ b/gitops/argocd/charts/wasm/wasmcloud/templates/http-hello-world-go.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/oam-dev/spec/refs/heads/master/schema/application_configuration.schema.json
 apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:

--- a/gitops/argocd/charts/wasm/wasmcloud/templates/http-hello-world-go.yaml
+++ b/gitops/argocd/charts/wasm/wasmcloud/templates/http-hello-world-go.yaml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: http-hello-world-go
+  annotations:
+    description: 'HTTP hello world demo in Golang (TinyGo), using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)'
+    wasmcloud.dev/authors: wasmCloud team
+    wasmcloud.dev/source-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/golang/components/http-hello-world/wadm.yaml
+    wasmcloud.dev/readme-md-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/golang/components/http-hello-world/README.md
+    wasmcloud.dev/homepage: https://github.com/wasmCloud/wasmCloud/tree/main/examples/golang/components/http-hello-world
+    wasmcloud.dev/categories: |
+      http,outgoing-http,http-server,tinygo,golang,example
+  labels:
+    {{- include "wadm.labels" (index .Subcharts "wadm") | nindent 4 }}
+spec:
+  components:
+    - name: http-component
+      type: component
+      properties:
+        image: file://./build/http_hello_world_s.wasm
+      traits:
+        # Govern the spread/scheduling of the component
+        - type: spreadscaler
+          properties:
+            instances: 1
+
+    # Add a capability provider that enables HTTP access
+    - name: httpserver
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/http-server:0.26.0
+      traits:
+        # Link the httpserver to the component, and configure the HTTP server
+        # to listen on port 8000 for incoming requests
+        #
+        # Since the HTTP server calls the `http-component` component, we establish
+        # a unidirectional link from this `httpserver` provider (the "source")
+        # to the `http-component` component (the "target"), so the server can invoke
+        # the component to handle a request.
+        - type: link
+          properties:
+            target:
+              name: http-component
+            namespace: wasi
+            package: http
+            interfaces: [incoming-handler]
+            source:
+              config:
+                - name: default-http
+                  properties:
+                    address: 0.0.0.0:8000

--- a/gitops/argocd/charts/wasm/wasmcloud/templates/http-hello-world-python.yaml
+++ b/gitops/argocd/charts/wasm/wasmcloud/templates/http-hello-world-python.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: http-hello-world-python
+  annotations:
+    description: 'Python component that uses wasi:http'
+    wasmcloud.dev/authors: wasmCloud team
+    wasmcloud.dev/source-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/python/http-hello-world/wadm.yaml
+    wasmcloud.dev/readme-md-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/python/http-hello-world/README.md
+    wasmcloud.dev/homepage: https://github.com/wasmCloud/wasmCloud/tree/main/examples/python/http-hello-world
+    wasmcloud.dev/categories: |
+      http,http-server,python,example
+  labels:
+    {{- include "wadm.labels" (index .Subcharts "wadm") | nindent 4 }}
+spec:
+  components:
+    - name: http-component
+      type: component
+      properties:
+        image: file://./build/http_hello_world_s.wasm
+      traits:
+        # Govern the spread/scheduling of the component
+        - type: spreadscaler
+          properties:
+            instances: 1
+
+    # Add a capability provider that enables HTTP access
+    - name: httpserver
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/http-server:0.26.0
+      traits:
+        # Link the httpserver to the component, and configure the HTTP server
+        # to listen on port 8000 for incoming requests
+        #
+        # Since the HTTP server calls the `http-component` component, we establish
+        # a unidirectional link from this `httpserver` provider (the "source")
+        # to the `http-component` component (the "target"), so the server can invoke
+        # the component to handle a request.
+        - type: link
+          properties:
+            target:
+              name: http-component
+            namespace: wasi
+            package: http
+            interfaces: [incoming-handler]
+            source:
+              config:
+                - name: default-http
+                  properties:
+                    address: 0.0.0.0:8000

--- a/gitops/argocd/charts/wasm/wasmcloud/templates/http-hello-world-python.yaml
+++ b/gitops/argocd/charts/wasm/wasmcloud/templates/http-hello-world-python.yaml
@@ -31,6 +31,14 @@ spec:
       type: capability
       properties:
         image: ghcr.io/wasmcloud/http-server:0.26.0
+        ## To configure OTEL integration for this provider specifically, uncomment the lines below
+        config:
+          - name: otel
+            properties:
+              otel_exporter_otlp_endpoint: "{{ .Values.wasmApps.opentelemetry.gateway.endpoint }}"
+              # otel_exporter_otlp_traces_endpoint: "http://traces-backend/v1/traces"
+              # otel_exporter_otlp_metrics_endpoint: "http://metrics-backend/v1/metrics"
+              # otel_exporter_otlp_logs_endpoint: "http://logs-backend/v1/logs"
       traits:
         # Link the httpserver to the component, and configure the HTTP server
         # to listen on port 8000 for incoming requests

--- a/gitops/argocd/charts/wasm/wasmcloud/templates/http-hello-world-python.yaml
+++ b/gitops/argocd/charts/wasm/wasmcloud/templates/http-hello-world-python.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/oam-dev/spec/refs/heads/master/schema/application_configuration.schema.json
 apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:

--- a/gitops/argocd/charts/wasm/wasmcloud/templates/http-hello-world-rust.yaml
+++ b/gitops/argocd/charts/wasm/wasmcloud/templates/http-hello-world-rust.yaml
@@ -34,13 +34,13 @@ spec:
       properties:
         image: ghcr.io/wasmcloud/http-server:0.26.0
         ## To configure OTEL integration for this provider specifically, uncomment the lines below
-        # config:
-        #   - name: otel
-        #     properties:
-        #       otel_exporter_otlp_endpoint: "http://all-in-one:4318"
-        #       otel_exporter_otlp_traces_endpoint: "http://traces-backend/v1/traces"
-        #       otel_exporter_otlp_metrics_endpoint: "http://metrics-backend/v1/metrics"
-        #       otel_exporter_otlp_logs_endpoint: "http://logs-backend/v1/logs"
+        config:
+          - name: otel
+            properties:
+              otel_exporter_otlp_endpoint: "{{ .Values.wasmApps.opentelemetry.gateway.endpoint }}"
+              # otel_exporter_otlp_traces_endpoint: "http://traces-backend/v1/traces"
+              # otel_exporter_otlp_metrics_endpoint: "http://metrics-backend/v1/metrics"
+              # otel_exporter_otlp_logs_endpoint: "http://logs-backend/v1/logs"
       traits:
         # Establish a unidirectional link from this http server provider (the "source")
         # to the `http-component` component (the "target") so the component can handle incoming HTTP requests,

--- a/gitops/argocd/charts/wasm/wasmcloud/templates/http-hello-world-rust.yaml
+++ b/gitops/argocd/charts/wasm/wasmcloud/templates/http-hello-world-rust.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: http-hello-world-rust
+  annotations:
+    description: 'HTTP hello world demo in Rust, using the WebAssembly Component Model and WebAssembly Interfaces Types (WIT)'
+    wasmcloud.dev/authors: wasmCloud team
+    wasmcloud.dev/source-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/rust/components/http-hello-world/wadm.yaml
+    wasmcloud.dev/readme-md-url: https://github.com/wasmCloud/wasmCloud/blob/main/examples/rust/components/http-hello-world/README.md
+    wasmcloud.dev/homepage: https://github.com/wasmCloud/wasmCloud/tree/main/examples/rust/components/http-hello-world
+    wasmcloud.dev/categories: |
+      http,http-server,rust,hello-world,example
+  labels:
+    {{- include "wadm.labels" (index .Subcharts "wadm") | nindent 4 }}
+spec:
+  components:
+    - name: http-component
+      type: component
+      properties:
+        image: file://./build/http_hello_world_s.wasm
+        # To use the a precompiled version of this component, use the line below instead:
+        # image: ghcr.io/wasmcloud/components/http-hello-world-rust:0.1.0
+      traits:
+        # Govern the spread/scheduling of the component
+        - type: spreadscaler
+          properties:
+            instances: 1
+
+    # Add a capability provider that enables HTTP access
+    - name: httpserver
+      type: capability
+      properties:
+        image: ghcr.io/wasmcloud/http-server:0.26.0
+        ## To configure OTEL integration for this provider specifically, uncomment the lines below
+        # config:
+        #   - name: otel
+        #     properties:
+        #       otel_exporter_otlp_endpoint: "http://all-in-one:4318"
+        #       otel_exporter_otlp_traces_endpoint: "http://traces-backend/v1/traces"
+        #       otel_exporter_otlp_metrics_endpoint: "http://metrics-backend/v1/metrics"
+        #       otel_exporter_otlp_logs_endpoint: "http://logs-backend/v1/logs"
+      traits:
+        # Establish a unidirectional link from this http server provider (the "source")
+        # to the `http-component` component (the "target") so the component can handle incoming HTTP requests,
+        #
+        # The source (this provider) is configured such that the HTTP server listens on 0.0.0.0:8000
+        - type: link
+          properties:
+            target:
+              name: http-component
+            namespace: wasi
+            package: http
+            interfaces: [incoming-handler]
+            source:
+              config:
+                - name: default-http
+                  properties:
+                    address: 0.0.0.0:8000

--- a/gitops/argocd/charts/wasm/wasmcloud/templates/http-hello-world-rust.yaml
+++ b/gitops/argocd/charts/wasm/wasmcloud/templates/http-hello-world-rust.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/oam-dev/spec/refs/heads/master/schema/application_configuration.schema.json
 apiVersion: core.oam.dev/v1beta1
 kind: Application
 metadata:

--- a/gitops/argocd/charts/wasm/wasmcloud/values-talos-homelab.yaml
+++ b/gitops/argocd/charts/wasm/wasmcloud/values-talos-homelab.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+wadm:
+  wadm:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
+      limits:
+        memory: 300Mi
+
+wasmcloud-operator:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 50Mi
+    limits:
+      memory: 300Mi

--- a/gitops/argocd/charts/wasm/wasmcloud/values.yaml
+++ b/gitops/argocd/charts/wasm/wasmcloud/values.yaml
@@ -9,3 +9,14 @@ wadm:
         server: "nats://nats-headless.messaging.svc.cluster.local"
 
 # wasmcloud-operator:
+
+wasmApps:
+  opentelemetry:
+    gateway:
+      endpoint: http://opentelemetry-collector-opentelemetry-gateway.opentelemetry.svc.cluster.local:4318
+    # logs:
+    #   endpoint: http://opentelemetry-collector-opentelemetry-gateway.opentelemetry.svc.cluster.local:4318
+    # metrics:
+    #   endpoint: http://opentelemetry-collector-opentelemetry-gateway.opentelemetry.svc.cluster.local:4318
+    # traces:
+    #   endpoint: http://opentelemetry-collector-opentelemetry-gateway.opentelemetry.svc.cluster.local:4318

--- a/gitops/argocd/charts/wasm/wasmcloud/values.yaml
+++ b/gitops/argocd/charts/wasm/wasmcloud/values.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+wadm:
+  wadm:
+    config:
+      nats:
+        server: "nats://nats-headless.messaging.svc.cluster.local"
+
+# wasmcloud-operator:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new Helm chart for the `wasmcloud` application, including versioning and dependencies.
  - Added configuration files to define resource requests and limits for `wadm` and `wasmcloud-operator`.
  - Created new application configurations for `http-hello-world-go`, `http-hello-world-python`, and `http-hello-world-rust` to facilitate deployment of WebAssembly-based HTTP servers.
  - Enhanced NATS configuration with new features, including WebSocket support, leaf nodes, and additional cluster settings.

- **Bug Fixes**
  - Updated the NATS dependency version from `1.1.11` to `1.2.10`.
  
- **Chores**
  - Removed obsolete `cluster` configuration from NATS settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->