### PR TITLE
Add alerting for OpenTelemetry collector

### DIFF
--- a/gitops/argocd/charts/opentelemetry/opentelemetry-collector/values.yaml
+++ b/gitops/argocd/charts/opentelemetry/opentelemetry-collector/values.yaml
@@ -1342,7 +1342,91 @@ opentelemetry-gateway:
 
   prometheusRule:
     enabled: true
-    groups: []
+    groups:
+    # Logs
+    - alert: OTelCollectorProcessorDroppedLogs
+      expr: sum(rate(otelcol_processor_dropped_log_records{}[1m])) > 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: Some log records have been dropped by processor
+        description: Maybe collector has received non standard log records or it reached some limits
+    - alert: OTelCollectorReceiverRefusedLogs
+      expr: sum(rate(otelcol_receiver_refused_log_records{}[1m])) > 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: Some log records have been refused by receiver
+        description: Maybe collector has received non standard log records or it reached some limits
+    - alert: OTelCollectorExporterEnqueuedLogs
+      expr: sum(rate(otelcol_exporter_enqueue_failed_log_records{}[1m])) > 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: Some log records have been enqueued by exporter
+        description: Maybe used destination has a problem or used payload is not correct
+    # Metrics
+    - alert: OTelCollectorPocessorDroppedMetrics
+      expr: sum(rate(otelcol_processor_dropped_metric_points{}[1m])) > 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: Some metric points have been dropped by processor
+        description: Maybe collector has received non standard metric points or it reached some limits
+    - alert: OTelCollectorReceiverRefusedMetrics
+      expr: sum(rate(otelcol_receiver_refused_metric_points{}[1m])) > 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: Some metric points have been refused by receiver
+        description: Maybe collector has received non standard metric points or it reached some limits
+    - alert: OTelCollectorExporterEnqueuedMetrics
+      expr: sum(rate(otelcol_exporter_enqueue_failed_metric_points{}[1m])) > 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: Some metric points have been enqueued by exporter
+        description: Maybe used destination has a problem or used payload is not correct
+    # Traces
+    - alert: OTelCollectorProcessorDroppedSpans
+      expr: sum(rate(otelcol_processor_dropped_spans{}[1m])) > 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: Some spans have been dropped by processor
+        description: Maybe collector has received non standard spans or it reached some limits
+    - alert: OtelCollectorReceiverRefusedSpans
+      expr: sum(rate(otelcol_receiver_refused_spans{}[1m])) > 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: Some spans have been refused by receiver
+        description: Maybe collector has received non standard spans or it reached some limits
+    - alert: OTelCollectorExporterEnqueuedSpans
+      expr: sum(rate(otelcol_exporter_enqueue_failed_spans{}[1m])) > 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: Some spans have been enqueued by exporter
+        description: Maybe used destination has a problem or used payload is not correct
+    # Common
+    - alert: OTelCollectorExporterFailedRequests
+      expr: sum(rate(otelcol_exporter_send_failed_requests{}[1m])) > 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: Some exporter requests failed
+        description: Maybe used destination has a problem or used payload is not correct
     defaultRules:
       enabled: true
     extraLabels:

--- a/gitops/argocd/charts/opentelemetry/opentelemetry-collector/values.yaml
+++ b/gitops/argocd/charts/opentelemetry/opentelemetry-collector/values.yaml
@@ -250,7 +250,7 @@ opentelemetry-logs:
     enabled: true
     groups: []
     defaultRules:
-      enabled: true
+      enabled: false
     extraLabels:
       prometheus.io/operator: portefaix
 
@@ -571,7 +571,7 @@ opentelemetry-metrics:
     enabled: true
     groups: []
     defaultRules:
-      enabled: true
+      enabled: false
     extraLabels:
       prometheus.io/operator: portefaix
 
@@ -1026,7 +1026,7 @@ opentelemetry-traces:
     enabled: true
     groups: []
     defaultRules:
-      enabled: true
+      enabled: false
     extraLabels:
       prometheus.io/operator: portefaix
 
@@ -1343,81 +1343,6 @@ opentelemetry-gateway:
   prometheusRule:
     enabled: true
     groups:
-    # Logs
-    - alert: OTelCollectorProcessorDroppedLogs
-      expr: sum(rate(otelcol_processor_dropped_log_records{}[1m])) > 0
-      for: 5m
-      labels:
-        severity: critical
-      annotations:
-        summary: Some log records have been dropped by processor
-        description: Maybe collector has received non standard log records or it reached some limits
-    - alert: OTelCollectorReceiverRefusedLogs
-      expr: sum(rate(otelcol_receiver_refused_log_records{}[1m])) > 0
-      for: 5m
-      labels:
-        severity: critical
-      annotations:
-        summary: Some log records have been refused by receiver
-        description: Maybe collector has received non standard log records or it reached some limits
-    - alert: OTelCollectorExporterEnqueuedLogs
-      expr: sum(rate(otelcol_exporter_enqueue_failed_log_records{}[1m])) > 0
-      for: 5m
-      labels:
-        severity: critical
-      annotations:
-        summary: Some log records have been enqueued by exporter
-        description: Maybe used destination has a problem or used payload is not correct
-    # Metrics
-    - alert: OTelCollectorPocessorDroppedMetrics
-      expr: sum(rate(otelcol_processor_dropped_metric_points{}[1m])) > 0
-      for: 5m
-      labels:
-        severity: critical
-      annotations:
-        summary: Some metric points have been dropped by processor
-        description: Maybe collector has received non standard metric points or it reached some limits
-    - alert: OTelCollectorReceiverRefusedMetrics
-      expr: sum(rate(otelcol_receiver_refused_metric_points{}[1m])) > 0
-      for: 5m
-      labels:
-        severity: critical
-      annotations:
-        summary: Some metric points have been refused by receiver
-        description: Maybe collector has received non standard metric points or it reached some limits
-    - alert: OTelCollectorExporterEnqueuedMetrics
-      expr: sum(rate(otelcol_exporter_enqueue_failed_metric_points{}[1m])) > 0
-      for: 5m
-      labels:
-        severity: critical
-      annotations:
-        summary: Some metric points have been enqueued by exporter
-        description: Maybe used destination has a problem or used payload is not correct
-    # Traces
-    - alert: OTelCollectorProcessorDroppedSpans
-      expr: sum(rate(otelcol_processor_dropped_spans{}[1m])) > 0
-      for: 5m
-      labels:
-        severity: critical
-      annotations:
-        summary: Some spans have been dropped by processor
-        description: Maybe collector has received non standard spans or it reached some limits
-    - alert: OtelCollectorReceiverRefusedSpans
-      expr: sum(rate(otelcol_receiver_refused_spans{}[1m])) > 0
-      for: 5m
-      labels:
-        severity: critical
-      annotations:
-        summary: Some spans have been refused by receiver
-        description: Maybe collector has received non standard spans or it reached some limits
-    - alert: OTelCollectorExporterEnqueuedSpans
-      expr: sum(rate(otelcol_exporter_enqueue_failed_spans{}[1m])) > 0
-      for: 5m
-      labels:
-        severity: critical
-      annotations:
-        summary: Some spans have been enqueued by exporter
-        description: Maybe used destination has a problem or used payload is not correct
     # Common
     - alert: OTelCollectorExporterFailedRequests
       expr: sum(rate(otelcol_exporter_send_failed_requests{}[1m])) > 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a critical alert for failed exporter requests to improve monitoring of data export issues.
- **Bug Fixes**
  - Disabled default Prometheus alerting rules for logs, metrics, and traces to reduce noise and focus on key alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->