### PR TITLE
fix(opentelemetry): fix filelog receiver, gateway otelarrow pipeline,…

### DIFF
--- a/gitops/argocd/charts/opentelemetry/opentelemetry-collector/templates/tracing-referencegrant.yaml
+++ b/gitops/argocd/charts/opentelemetry/opentelemetry-collector/templates/tracing-referencegrant.yaml
@@ -17,3 +17,4 @@ spec:
   - group: ""
     kind: Service
     name: {{ .Values.gateway.opentelemetry.tracing.service -}}
+{{- end }}

--- a/gitops/argocd/charts/opentelemetry/opentelemetry-collector/values-talos-homelab.yaml
+++ b/gitops/argocd/charts/opentelemetry/opentelemetry-collector/values-talos-homelab.yaml
@@ -16,8 +16,8 @@ opentelemetry-logs:
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
-  # - name: K8S_CLUSTER_NAME
-  #   value: "portefaix-talos-homelab"
+  - name: K8S_CLUSTER_NAME
+    value: "portefaix-talos-homelab"
   # - name: K8S_ENVIRONMENT_NAME
   #   value: "homelab"
   # - name: OTEL_RESOURCE_ATTRIBUTES

--- a/gitops/argocd/charts/opentelemetry/opentelemetry-collector/values.yaml
+++ b/gitops/argocd/charts/opentelemetry/opentelemetry-collector/values.yaml
@@ -46,10 +46,6 @@ opentelemetry-logs:
 
   config:
     extensions:
-      file_storage:
-        directory: /var/otelcol/storage
-        timeout: 10s
-
     receivers:
       jaeger: {}
       otlp:
@@ -74,7 +70,7 @@ opentelemetry-logs:
         include_file_path: true
         exclude_older_than: 24h
         start_at: end # beginning
-        storage: file_storage
+
         operators:
         - id: container-parser
           max_log_size: 102400
@@ -290,7 +286,7 @@ opentelemetry-logs:
         timeout: 30s
 
     service:
-      extensions: [health_check, file_storage]
+      extensions: [health_check]
       telemetry:
         logs:
           level: info

--- a/gitops/argocd/charts/opentelemetry/opentelemetry-collector/values.yaml
+++ b/gitops/argocd/charts/opentelemetry/opentelemetry-collector/values.yaml
@@ -45,6 +45,11 @@ opentelemetry-logs:
       enabled: false
 
   config:
+    extensions:
+      file_storage:
+        directory: /var/otelcol/storage
+        timeout: 10s
+
     receivers:
       jaeger: {}
       otlp:
@@ -69,6 +74,7 @@ opentelemetry-logs:
         include_file_path: true
         exclude_older_than: 24h
         start_at: end # beginning
+        storage: file_storage
         operators:
         - id: container-parser
           max_log_size: 102400
@@ -85,6 +91,10 @@ opentelemetry-logs:
           field: resource["k8s.cluster.name"]
           value: EXPR(env("K8S_CLUSTER_NAME"))
           output: move_stream
+        - id: move_stream
+          type: move
+          from: attributes["log.iostream"]
+          to: attributes["stream"]
         retry_on_failure:
           enabled: true
 
@@ -225,10 +235,10 @@ opentelemetry-logs:
         log_statements:
         - context: log
           statements:
-          - set(log.time, Now()) where log.time == nil
-          - set(log.observed_time, Now()) where log.observed_time == nil
-          - set(log.severity_text, "INFO") where log.severity_text == nil or log.severity_text == ""
-          - set(log.severity_number, SEVERITY_NUMBER_INFO) where IsMatch(log.severity_text, "INFO") # https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber
+          - set(time, Now()) where time == nil
+          - set(observed_time, Now()) where observed_time == nil
+          - set(severity_text, "INFO") where severity_text == nil or severity_text == ""
+          - set(severity_number, SEVERITY_NUMBER_INFO) where IsMatch(severity_text, "INFO") # https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber
 
       # 3. Promote trace context from attributes to top-level fields; nil guards prevent
       #    a missing field from causing errors that would drop an entire batch
@@ -280,6 +290,7 @@ opentelemetry-logs:
         timeout: 30s
 
     service:
+      extensions: [health_check, file_storage]
       telemetry:
         logs:
           level: info
@@ -657,7 +668,6 @@ opentelemetry-metrics:
           - filter/drop_test_metrics
           - batch
           exporters:
-          - debug
           - otlparrow/gateway
         traces: null
 
@@ -896,7 +906,6 @@ opentelemetry-metrics-cluster:
           - k8sattributes
           - batch
           exporters:
-          - debug
           - otlparrow/gateway
         metrics:
           receivers:
@@ -911,7 +920,6 @@ opentelemetry-metrics-cluster:
           # - transform
           - batch
           exporters:
-          - debug
           - otlparrow/gateway
         traces: null
 
@@ -1193,7 +1201,6 @@ opentelemetry-traces:
           # - transform
           - batch
           exporters:
-          - debug
           - otlparrow/gateway
         traces/sampling:
           receivers:
@@ -1204,7 +1211,6 @@ opentelemetry-traces:
           - k8sattributes
           - batch
           exporters:
-          - debug
           - otlparrow/gateway
 
   ports:
@@ -1294,8 +1300,7 @@ opentelemetry-gateway:
       zipkin: null
       otlp:
         protocols:
-          grpc:
-            endpoint: ${env:MY_POD_IP}:4317
+          # grpc removed: otelarrow on 4317 is a superset (handles both Arrow and OTLP/gRPC)
           http:
             endpoint: ${env:MY_POD_IP}:4318
       otelarrow:
@@ -1400,18 +1405,18 @@ opentelemetry-gateway:
         table:
         - context: resource
           condition: |
-            resource.attributes["service.namespace"] == "gitops"' or
-            resource.attributes["service.namespace"] == "logging"' or
-            resource.attributes["service.namespace"] == "monitoring"' or
-            resource.attributes["service.namespace"] == "observability"'
-            resource.attributes["service.namespace"] == "opentelemetry"'
+            resource.attributes["service.namespace"] == "gitops" or
+            resource.attributes["service.namespace"] == "logging" or
+            resource.attributes["service.namespace"] == "monitoring" or
+            resource.attributes["service.namespace"] == "observability" or
+            resource.attributes["service.namespace"] == "opentelemetry"
           pipelines:
           - logs/saas
           - logs/local
           - logs/datadog
         - context: resource
           condition: |
-            resource.attributes["service.namespace"] != "default"'
+            resource.attributes["service.namespace"] != "default"
           pipelines:
           - logs/local
 
@@ -1422,19 +1427,19 @@ opentelemetry-gateway:
         table:
         - context: resource
           condition: |
-            resource.attributes["service.namespace"] == "gitops"' or
-            resource.attributes["service.namespace"] == "kube-system"' or
-            resource.attributes["service.namespace"] == "logging"' or
-            resource.attributes["service.namespace"] == "monitoring"' or
-            resource.attributes["service.namespace"] == "observability"'
-            resource.attributes["service.namespace"] == "opentelemetry"'
+            resource.attributes["service.namespace"] == "gitops" or
+            resource.attributes["service.namespace"] == "kube-system" or
+            resource.attributes["service.namespace"] == "logging" or
+            resource.attributes["service.namespace"] == "monitoring" or
+            resource.attributes["service.namespace"] == "observability" or
+            resource.attributes["service.namespace"] == "opentelemetry"
           pipelines:
           - metrics/saas
           - metrics/local
           - metrics/datadog
         - context: resource
           condition: |
-            resource.attributes["service.namespace"] != "default"'
+            resource.attributes["service.namespace"] != "default"
           pipelines:
           - metrics/local
 
@@ -1445,16 +1450,16 @@ opentelemetry-gateway:
         table:
         - context: resource
           condition: |
-            resource.attributes["service.namespace"] == "gitops"' or
-            resource.attributes["service.namespace"] == "kube-system"' or
-            resource.attributes["service.namespace"] == "observability"'
+            resource.attributes["service.namespace"] == "gitops" or
+            resource.attributes["service.namespace"] == "kube-system" or
+            resource.attributes["service.namespace"] == "observability"
           pipelines:
           - traces/saas
           - traces/local
           - traces/datadog
         - context: resource
           condition: |
-            resource.attributes["service.namespace"] != "default"'
+            resource.attributes["service.namespace"] != "default"
           pipelines:
           - traces/local
 
@@ -1621,6 +1626,7 @@ opentelemetry-gateway:
         # OpenTelemetry / Logs
         logs/in:
           receivers:
+          - otelarrow
           - otlp
           processors:
           - memory_limiter
@@ -1672,6 +1678,7 @@ opentelemetry-gateway:
 
         metrics/in:
           receivers:
+          - otelarrow
           - otlp
           - prometheus
           processors:
@@ -1723,6 +1730,7 @@ opentelemetry-gateway:
 
         traces/in:
           receivers:
+          - otelarrow
           - otlp
           processors:
           - memory_limiter

--- a/gitops/argocd/charts/opentelemetry/opentelemetry-collector/values.yaml
+++ b/gitops/argocd/charts/opentelemetry/opentelemetry-collector/values.yaml
@@ -1300,7 +1300,7 @@ opentelemetry-gateway:
       zipkin: null
       otlp:
         protocols:
-          # grpc removed: otelarrow on 4317 is a superset (handles both Arrow and OTLP/gRPC)
+          grpc: null  # otelarrow on 4317 is a superset (handles both Arrow and OTLP/gRPC)
           http:
             endpoint: ${env:MY_POD_IP}:4318
       otelarrow:


### PR DESCRIPTION
Several bugs were identified via a review against the Dash0 filelog receiver guide and OpenTelemetry best practices:

- Add missing `move_stream` operator to complete the filelog operator chain (dangling output reference caused startup failures)
- Fix OTTL field paths in transform/logs_normalize: remove incorrect `log.` prefix (standard OTTL log context uses bare field names)
- Remove `debug` exporter from all production pipelines to reduce overhead and log noise
- Fix gateway otelarrow port conflict: remove duplicate otlp grpc binding on port 4317 (otelarrow is a superset of OTLP/gRPC)
- Add `otelarrow` receiver to gateway logs/in, metrics/in, traces/in pipelines so Arrow-compressed agent traffic is actually forwarded
- Fix OTTL syntax in routing connector conditions: remove spurious single quotes and add missing `or` operator in logs/metrics tables
- Uncomment K8S_CLUSTER_NAME env var in homelab values so the filelog add_cluster_name operator resolves to a non-empty value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced telemetry ingestion with file-backed log storage and stream normalization
  * Added otel-arrow receiver support and health checks across pipelines
  * Strengthened gateway routing to accept telemetry from the opentelemetry namespace and improved cluster-context enrichment

* **Bug Fixes**
  * Fixed template rendering so gateway-related resources are conditionally applied correctly

* **Chores**
  * Activated cluster identification in homelab config
  * Removed debug exporters to reduce noise and updated observability configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->