### PR TITLE
feat(krm): add multi-cloud KRM environment configurations

### DIFF
--- a/gitops/argocd/apps/ai/values-aws-staging.yaml
+++ b/gitops/argocd/apps/ai/values-aws-staging.yaml
@@ -20,9 +20,9 @@ argocd-apps:
             argocd.argoproj.io/manifest-generate-paths: "/{{path}}"
             notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-staging-gitops
-            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-staging-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-staging-gitops
-            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-staging-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-staging-gitops
           finalizers:
           - resources-finalizer.argocd.argoproj.io

--- a/gitops/argocd/apps/ai/values-talos-homelab.yaml
+++ b/gitops/argocd/apps/ai/values-talos-homelab.yaml
@@ -25,9 +25,9 @@ argocd-apps:
           annotations:
             notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-homelab-gitops
-            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-homelab-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-homelab-gitops
-            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-homelab-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-homelab-gitops
           labels:
             portefaix.xyz/env: homelab

--- a/gitops/argocd/apps/chaos/values-aws-staging.yaml
+++ b/gitops/argocd/apps/chaos/values-aws-staging.yaml
@@ -23,9 +23,9 @@ argocd-apps:
             argocd.argoproj.io/manifest-generate-paths: "/{{path}}"
             notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-staging-gitops
-            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-staging-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-staging-gitops
-            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-staging-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-staging-gitops
           finalizers:
           - resources-finalizer.argocd.argoproj.io

--- a/gitops/argocd/apps/chaos/values-talos-homelab.yaml
+++ b/gitops/argocd/apps/chaos/values-talos-homelab.yaml
@@ -22,9 +22,9 @@ argocd-apps:
           annotations:
             notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-homelab-gitops
-            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-homelab-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-homelab-gitops
-            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-homelab-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-homelab-gitops
           labels:
             portefaix.xyz/env: homelab

--- a/gitops/argocd/apps/core/values-aws-staging.yaml
+++ b/gitops/argocd/apps/core/values-aws-staging.yaml
@@ -68,9 +68,9 @@ argocd-apps:
             argocd.argoproj.io/manifest-generate-paths: "/{{path}}"
             notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-staging-gitops
-            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-staging-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-staging-gitops
-            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-staging-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-staging-gitops
           finalizers:
           - resources-finalizer.argocd.argoproj.io

--- a/gitops/argocd/apps/core/values-talos-homelab.yaml
+++ b/gitops/argocd/apps/core/values-talos-homelab.yaml
@@ -74,9 +74,9 @@ argocd-apps:
           annotations:
             notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-homelab-gitops
-            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-homelab-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-homelab-gitops
-            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-homelab-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-homelab-gitops
           labels:
             portefaix.xyz/env: homelab

--- a/gitops/argocd/apps/demo/values-aws-staging.yaml
+++ b/gitops/argocd/apps/demo/values-aws-staging.yaml
@@ -29,9 +29,9 @@ argocd-apps:
             argocd.argoproj.io/manifest-generate-paths: "/{{path}}"
             notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-staging-gitops
-            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-staging-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-staging-gitops
-            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-staging-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-staging-gitops
           finalizers:
           - resources-finalizer.argocd.argoproj.io

--- a/gitops/argocd/apps/demo/values-talos-homelab.yaml
+++ b/gitops/argocd/apps/demo/values-talos-homelab.yaml
@@ -36,9 +36,9 @@ argocd-apps:
           annotations:
             notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-homelab-gitops
-            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-homelab-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-homelab-gitops
-            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-homelab-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-homelab-gitops
           labels:
             portefaix.xyz/env: homelab

--- a/gitops/argocd/apps/krm/values-aws-staging.yaml
+++ b/gitops/argocd/apps/krm/values-aws-staging.yaml
@@ -23,9 +23,9 @@ argocd-apps:
             argocd.argoproj.io/manifest-generate-paths: "/{{path}}"
             notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-staging-gitops
-            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-staging-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-staging-gitops
-            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-staging-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-staging-gitops
           finalizers:
           - resources-finalizer.argocd.argoproj.io

--- a/gitops/argocd/apps/krm/values-gcp-dev.yaml
+++ b/gitops/argocd/apps/krm/values-gcp-dev.yaml
@@ -23,9 +23,9 @@ argocd-apps:
             argocd.argoproj.io/manifest-generate-paths: "/{{path}}"
             notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-gcp-dev-gitops
             notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-gcp-dev-gitops
-            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-gcp-dev-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed.slack: portefaix-gcp-dev-gitops
             notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-gcp-dev-gitops
-            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-gcp-dev-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: portefaix-gcp-dev-gitops
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-gcp-dev-gitops
           finalizers:
           - resources-finalizer.argocd.argoproj.io

--- a/gitops/argocd/apps/krm/values-gcp-dev.yaml
+++ b/gitops/argocd/apps/krm/values-gcp-dev.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+argocd-apps:
+  applicationsets:
+    tools:
+      additionalLabels:
+        portefaix.xyz/env: dev
+      additionalAnnotations: {}
+      generators:
+      - list:
+          elements:
+          - appName: kro
+            namespace: krm
+            targetRevision: HEAD
+          - appName: config-connector
+            namespace: krm
+            targetRevision: HEAD
+      template:
+        metadata:
+          annotations:
+            argocd.argoproj.io/manifest-generate-paths: "/{{path}}"
+            notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-gcp-dev-gitops
+            notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-gcp-dev-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-gcp-dev-gitops
+            notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-gcp-dev-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-gcp-dev-gitops
+            notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-gcp-dev-gitops
+          finalizers:
+          - resources-finalizer.argocd.argoproj.io
+          labels:
+            portefaix.xyz/env: dev
+        spec:
+          project: portefaix-gcp-dev
+          source:
+            helm:
+              valueFiles:
+              - values.yaml
+              - values-gcp-dev.yaml

--- a/gitops/argocd/apps/krm/values-scw-sandbox.yaml
+++ b/gitops/argocd/apps/krm/values-scw-sandbox.yaml
@@ -23,9 +23,9 @@ argocd-apps:
             argocd.argoproj.io/manifest-generate-paths: "/{{path}}"
             notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-scw-sandbox-gitops
             notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-scw-sandbox-gitops
-            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-scw-sandbox-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed.slack: portefaix-scw-sandbox-gitops
             notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-scw-sandbox-gitops
-            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-scw-sandbox-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: portefaix-scw-sandbox-gitops
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-scw-sandbox-gitops
           finalizers:
           - resources-finalizer.argocd.argoproj.io

--- a/gitops/argocd/apps/krm/values-scw-sandbox.yaml
+++ b/gitops/argocd/apps/krm/values-scw-sandbox.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+argocd-apps:
+  applicationsets:
+    tools:
+      additionalLabels:
+        portefaix.xyz/env: sandbox
+      additionalAnnotations: {}
+      generators:
+      - list:
+          elements:
+          - appName: kro
+            namespace: krm
+            targetRevision: HEAD
+          - appName: crossplane
+            namespace: krm
+            targetRevision: HEAD
+      template:
+        metadata:
+          annotations:
+            argocd.argoproj.io/manifest-generate-paths: "/{{path}}"
+            notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-scw-sandbox-gitops
+            notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-scw-sandbox-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-scw-sandbox-gitops
+            notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-scw-sandbox-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-scw-sandbox-gitops
+            notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-scw-sandbox-gitops
+          finalizers:
+          - resources-finalizer.argocd.argoproj.io
+          labels:
+            portefaix.xyz/env: sandbox
+        spec:
+          project: portefaix-scw-sandbox
+          source:
+            helm:
+              valueFiles:
+              - values.yaml
+              - values-scw-sandbox.yaml

--- a/gitops/argocd/apps/krm/values-talos-homelab.yaml
+++ b/gitops/argocd/apps/krm/values-talos-homelab.yaml
@@ -14,9 +14,6 @@ argocd-apps:
           - appName: kro
             namespace: krm
             targetRevision: HEAD
-          - appName: ack
-            namespace: krm
-            targetRevision: HEAD
       template:
         metadata:
           annotations:

--- a/gitops/argocd/apps/krm/values-talos-homelab.yaml
+++ b/gitops/argocd/apps/krm/values-talos-homelab.yaml
@@ -19,9 +19,9 @@ argocd-apps:
           annotations:
             notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-homelab-gitops
-            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-homelab-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-homelab-gitops
-            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-homelab-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-homelab-gitops
           labels:
             portefaix.xyz/env: homelab

--- a/gitops/argocd/apps/networking/values-aws-staging.yaml
+++ b/gitops/argocd/apps/networking/values-aws-staging.yaml
@@ -35,9 +35,9 @@ argocd-apps:
             argocd.argoproj.io/manifest-generate-paths: "/{{path}}"
             notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-staging-gitops
-            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-staging-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-staging-gitops
-            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-staging-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-staging-gitops
           finalizers:
           - resources-finalizer.argocd.argoproj.io

--- a/gitops/argocd/apps/networking/values-talos-homelab.yaml
+++ b/gitops/argocd/apps/networking/values-talos-homelab.yaml
@@ -40,9 +40,9 @@ argocd-apps:
           annotations:
             notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-homelab-gitops
-            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-homelab-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-homelab-gitops
-            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-homelab-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-homelab-gitops
           labels:
             portefaix.xyz/env: homelab

--- a/gitops/argocd/apps/observability/values-aws-staging.yaml
+++ b/gitops/argocd/apps/observability/values-aws-staging.yaml
@@ -59,9 +59,9 @@ argocd-apps:
             argocd.argoproj.io/manifest-generate-paths: "/{{path}}"
             notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-staging-gitops
-            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-staging-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-staging-gitops
-            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-staging-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-staging-gitops
           finalizers:
           - resources-finalizer.argocd.argoproj.io

--- a/gitops/argocd/apps/observability/values-talos-homelab.yaml
+++ b/gitops/argocd/apps/observability/values-talos-homelab.yaml
@@ -96,9 +96,9 @@ argocd-apps:
           annotations:
             notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-homelab-gitops
-            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-homelab-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-homelab-gitops
-            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-homelab-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-homelab-gitops
           labels:
             portefaix.xyz/env: homelab

--- a/gitops/argocd/apps/security/values-aws-staging.yaml
+++ b/gitops/argocd/apps/security/values-aws-staging.yaml
@@ -47,9 +47,9 @@ argocd-apps:
             argocd.argoproj.io/manifest-generate-paths: "/{{path}}"
             notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-staging-gitops
-            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-staging-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-staging-gitops
-            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-staging-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-staging-gitops
           finalizers:
           - resources-finalizer.argocd.argoproj.io

--- a/gitops/argocd/apps/security/values-talos-homelab.yaml
+++ b/gitops/argocd/apps/security/values-talos-homelab.yaml
@@ -52,9 +52,9 @@ argocd-apps:
           annotations:
             notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-homelab-gitops
-            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-homelab-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-homelab-gitops
-            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-homelab-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-homelab-gitops
           labels:
             portefaix.xyz/env: homelab

--- a/gitops/argocd/apps/system/values-aws-staging.yaml
+++ b/gitops/argocd/apps/system/values-aws-staging.yaml
@@ -29,9 +29,9 @@ argocd-apps:
             argocd.argoproj.io/manifest-generate-paths: "/{{path}}"
             notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-staging-gitops
-            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-staging-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-staging-gitops
-            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-staging-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-staging-gitops
           finalizers:
           - resources-finalizer.argocd.argoproj.io

--- a/gitops/argocd/apps/system/values-talos-homelab.yaml
+++ b/gitops/argocd/apps/system/values-talos-homelab.yaml
@@ -55,9 +55,9 @@ argocd-apps:
           annotations:
             notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-homelab-gitops
-            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-homelab-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-homelab-gitops
-            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-homelab-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-homelab-gitops
           labels:
             portefaix.xyz/env: homelab

--- a/gitops/argocd/apps/tools/values-aws-staging.yaml
+++ b/gitops/argocd/apps/tools/values-aws-staging.yaml
@@ -32,9 +32,9 @@ argocd-apps:
             argocd.argoproj.io/manifest-generate-paths: "/{{path}}"
             notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-staging-gitops
-            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-staging-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-staging-gitops
-            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-staging-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: portefaix-staging-gitops
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-staging-gitops
           finalizers:
           - resources-finalizer.argocd.argoproj.io

--- a/gitops/argocd/apps/tools/values-talos-homelab.yaml
+++ b/gitops/argocd/apps/tools/values-talos-homelab.yaml
@@ -46,9 +46,9 @@ argocd-apps:
           annotations:
             notifications.argoproj.io/subscribe.on-degraded.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-deployed.slack: portefaix-homelab-gitops
-            notifications.argoproj.io/subscribe.on-sync-failed: portefaix-homelab-gitops
+            notifications.argoproj.io/subscribe.on-sync-failed.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-sync-running.slack: portefaix-homelab-gitops
-            notifications.argoproj.io/subscribe.on-sync-status-unknown: portefaix-homelab-gitops
+            notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: portefaix-homelab-gitops
             notifications.argoproj.io/subscribe.on-sync-succeeded.slack: portefaix-homelab-gitops
           labels:
             portefaix.xyz/env: homelab

--- a/gitops/argocd/charts/krm/ack/values-aws-staging.yaml
+++ b/gitops/argocd/charts/krm/ack/values-aws-staging.yaml
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+ack-chart:
+  apigatewayv2:
+    deployment:
+      replicas: 2
+    metrics:
+      serviceMonitor:
+        relabelings:
+        - action: replace
+          replacement: portefaix-aws-staging
+          targetLabel: cluster
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "50m"
+      limits:
+        memory: "256Mi"
+        cpu: "200m"
+
+  ecr:
+    deployment:
+      replicas: 2
+    metrics:
+      serviceMonitor:
+        relabelings:
+        - action: replace
+          replacement: portefaix-aws-staging
+          targetLabel: cluster
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "50m"
+      limits:
+        memory: "256Mi"
+        cpu: "200m"
+
+  iam:
+    deployment:
+      replicas: 2
+    metrics:
+      serviceMonitor:
+        relabelings:
+        - action: replace
+          replacement: portefaix-aws-staging
+          targetLabel: cluster
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "50m"
+      limits:
+        memory: "256Mi"
+        cpu: "200m"
+
+  kms:
+    deployment:
+      replicas: 2
+    metrics:
+      serviceMonitor:
+        relabelings:
+        - action: replace
+          replacement: portefaix-aws-staging
+          targetLabel: cluster
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "50m"
+      limits:
+        memory: "256Mi"
+        cpu: "200m"
+
+  s3:
+    deployment:
+      replicas: 2
+    metrics:
+      serviceMonitor:
+        relabelings:
+        - action: replace
+          replacement: portefaix-aws-staging
+          targetLabel: cluster
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "50m"
+      limits:
+        memory: "256Mi"
+        cpu: "200m"
+
+  secretsmanager:
+    deployment:
+      replicas: 2
+    metrics:
+      serviceMonitor:
+        relabelings:
+        - action: replace
+          replacement: portefaix-aws-staging
+          targetLabel: cluster
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "50m"
+      limits:
+        memory: "256Mi"
+        cpu: "200m"
+
+  sns:
+    deployment:
+      replicas: 2
+    metrics:
+      serviceMonitor:
+        relabelings:
+        - action: replace
+          replacement: portefaix-aws-staging
+          targetLabel: cluster
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "50m"
+      limits:
+        memory: "256Mi"
+        cpu: "200m"
+
+  sqs:
+    deployment:
+      replicas: 2
+    metrics:
+      serviceMonitor:
+        relabelings:
+        - action: replace
+          replacement: portefaix-aws-staging
+          targetLabel: cluster
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "50m"
+      limits:
+        memory: "256Mi"
+        cpu: "200m"
+
+  wafv2:
+    deployment:
+      replicas: 2
+    metrics:
+      serviceMonitor:
+        relabelings:
+        - action: replace
+          replacement: portefaix-aws-staging
+          targetLabel: cluster
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "50m"
+      limits:
+        memory: "256Mi"
+        cpu: "200m"

--- a/gitops/argocd/charts/krm/crossplane/Chart.yaml
+++ b/gitops/argocd/charts/krm/crossplane/Chart.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: v2
+type: application
+name: crossplane
+version: 1.0.0
+appVersion: 1.0.0
+dependencies:
+- name: crossplane
+  # See: https://github.com/crossplane/crossplane/issues/6707
+  repository: oci://ghcr.io/home-operations/charts-mirror
+  version: 2.2.1

--- a/gitops/argocd/charts/krm/crossplane/values-scw-sandbox.yaml
+++ b/gitops/argocd/charts/krm/crossplane/values-scw-sandbox.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+crossplane:
+  resourcesCrossplane:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      memory: "512Mi"
+
+  resourcesRBACManager:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      memory: "512Mi"
+
+  # provider-scaleway: https://github.com/scaleway/crossplane-provider-scaleway
+  provider:
+    packages:
+    - xpkg.upbound.io/scaleway/provider-scaleway:latest

--- a/gitops/argocd/charts/krm/crossplane/values-scw-sandbox.yaml
+++ b/gitops/argocd/charts/krm/crossplane/values-scw-sandbox.yaml
@@ -20,4 +20,4 @@ crossplane:
   # provider-scaleway: https://github.com/scaleway/crossplane-provider-scaleway
   provider:
     packages:
-    - xpkg.upbound.io/scaleway/provider-scaleway:latest
+    - xpkg.upbound.io/scaleway/provider-scaleway:v0.5.0

--- a/gitops/argocd/charts/krm/crossplane/values-talos-homelab.yaml
+++ b/gitops/argocd/charts/krm/crossplane/values-talos-homelab.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+crossplane:
+  resourcesCrossplane:
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+    limits:
+      memory: "256Mi"
+
+  resourcesRBACManager:
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+    limits:
+      memory: "256Mi"

--- a/gitops/argocd/charts/krm/crossplane/values.yaml
+++ b/gitops/argocd/charts/krm/crossplane/values.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+crossplane:
+  additionalLabels:
+    portefaix.xyz/version: v1.3.0
+
+  resourcesCrossplane:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      memory: "512Mi"
+
+  resourcesRBACManager:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      memory: "512Mi"
+
+  metrics:
+    enabled: true
+
+  # Providers installed separately via Provider CRs in gitops/argocd/charts/krm/kro-apps.
+  provider:
+    packages: []

--- a/gitops/argocd/charts/krm/kro/values-aws-staging.yaml
+++ b/gitops/argocd/charts/krm/kro/values-aws-staging.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+kro:
+  deployment:
+    replicaCount: 2
+
+  metrics:
+    serviceMonitor:
+      relabelings:
+      - action: replace
+        replacement: portefaix-aws-staging
+        targetLabel: cluster

--- a/gitops/argocd/charts/krm/kro/values-gcp-dev.yaml
+++ b/gitops/argocd/charts/krm/kro/values-gcp-dev.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+kro:
+  deployment:
+    replicaCount: 2
+
+  metrics:
+    serviceMonitor:
+      relabelings:
+      - action: replace
+        replacement: portefaix-gcp-dev
+        targetLabel: cluster

--- a/gitops/argocd/charts/krm/kro/values-scw-sandbox.yaml
+++ b/gitops/argocd/charts/krm/kro/values-scw-sandbox.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+kro:
+  deployment:
+    replicaCount: 1
+
+  metrics:
+    serviceMonitor:
+      relabelings:
+      - action: replace
+        replacement: portefaix-scw-sandbox
+        targetLabel: cluster

--- a/gitops/argocd/stacks/values-aws-staging-krm.yaml
+++ b/gitops/argocd/stacks/values-aws-staging-krm.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+project:
+  name: portefaix-aws-staging
+
+stack:
+  name: krm
+  source:
+    helm:
+      valueFiles:
+      - values.yaml
+      - values-aws-staging.yaml
+
+notifications:
+  slack:
+    channel: portefaix-aws-staging-gitops

--- a/gitops/argocd/stacks/values-gcp-dev-krm.yaml
+++ b/gitops/argocd/stacks/values-gcp-dev-krm.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+project:
+  name: portefaix-gcp-dev
+
+stack:
+  name: krm
+  source:
+    helm:
+      valueFiles:
+      - values.yaml
+      - values-gcp-dev.yaml
+
+notifications:
+  slack:
+    channel: portefaix-gcp-dev-gitops

--- a/gitops/argocd/stacks/values-scw-sandbox-krm.yaml
+++ b/gitops/argocd/stacks/values-scw-sandbox-krm.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+project:
+  name: portefaix-scw-sandbox
+
+stack:
+  name: krm
+  source:
+    helm:
+      valueFiles:
+      - values.yaml
+      - values-scw-sandbox.yaml
+
+notifications:
+  slack:
+    channel: portefaix-scw-sandbox-gitops


### PR DESCRIPTION
Introduces KRM support for AWS, GCP and SCW.
Adds per-environment Helm values for kro, crossplane, and ACK. Introduces Crossplane chart and removes legacy ACK from talos-homelab AppSet.