### PR TITLE
fix(workflows): update default branch to main

### DIFF
--- a/.github/workflows/argo-build.yml
+++ b/.github/workflows/argo-build.yml
@@ -8,13 +8,13 @@ name: Argo / Build
 on: # yamllint disable-line rule:truthy
   pull_request:
     branches:
-    - master
+    - main
     paths:
     - "gitops/argocd/**"
     - ".github/actions/tools/**"
     # push:
     #   branches:
-    #     - master
+    #     - main
     #   paths:
     #     - 'gitops/argocd/clusters/**'
     #     - 'gitops/argocdcd/kubernetes/**'

--- a/.github/workflows/flux-build.yml
+++ b/.github/workflows/flux-build.yml
@@ -8,14 +8,14 @@ name: Flux / Build
 on: # yamllint disable-line rule:truthy
   pull_request:
     branches:
-    - master
+    - main
     paths:
     - "gitops/fluxcd/clusters/**"
     - "gitops/fluxcd/kubernetes/**"
     - ".github/actions/tools/**"
     # push:
     #   branches:
-    #     - master
+    #     - main
     #   paths:
     #     - 'gitops/fluxcd/clusters/**'
     #     - 'gitops/fluxcd/kubernetes/**'

--- a/.github/workflows/flux-e2e.yml
+++ b/.github/workflows/flux-e2e.yml
@@ -8,13 +8,13 @@ name: Flux / E2E
 on: # yamllint disable-line rule:truthy
   pull_request:
     branches:
-    - master
+    - main
     paths:
     - "gitops/fluxcd/clusters/**"
     - "gitops/fluxcd/kubernetes/**"
     # push:
     #   branches:
-    #     - master
+    #     - main
     #   paths:
     #     - 'gitops/fluxcd/clusters/**'
     #     - 'gitops/fluxcd/kubernetes/**'

--- a/.github/workflows/flux-opa.yml
+++ b/.github/workflows/flux-opa.yml
@@ -8,13 +8,13 @@ name: Flux / OPA Policies
 on: # yamllint disable-line rule:truthy
   pull_request:
     branches:
-    - master
+    - main
     paths:
     - "gitops/fluxcd/clusters/**"
     - "gitops/fluxcd/kubernetes/**"
     # push:
     #   branches:
-    #     - master
+    #     - main
     #   paths:
     #     - 'gitops/fluxcd/clusters/**'
     #     - 'gitops/fluxcd/kubernetes/**'

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -7,12 +7,10 @@ on:
   # Run on pushes to default branch
   push:
     branches:
-    - master
     - main
   # Run on pull requests
   pull_request:
     branches:
-    - master
     - main
   # Run on schedule (weekly)
   schedule:

--- a/.github/workflows/project-labels.yml
+++ b/.github/workflows/project-labels.yml
@@ -8,7 +8,7 @@ name: Project / PR Branch Labeler
 on: # yamllint disable-line rule:truthy
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
   label-pr:

--- a/.github/workflows/prow-lgtm-pull.yml
+++ b/.github/workflows/prow-lgtm-pull.yml
@@ -8,7 +8,7 @@ name: Prow / Run Jobs on PR
 on: # yamllint disable-line rule:truthy
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
   execute:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,7 +6,6 @@ name: Release Please
 on:
   push:
     branches:
-    - master
     - main
 
 permissions:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -13,7 +13,7 @@ on:
   schedule:
   - cron: "20 7 * * 2"
   push:
-    branches: ["master"]
+    branches: ["main"]
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
## Summary

- Update all GitHub Actions workflows to use 'main' as default branch
- Replace all 'master' references with 'main' in 9 workflow files
- Follows repository branch rename from master to main