### PR TITLE
Add ACK manifests for Loki resources

### DIFF
--- a/gitops/argocd/charts/krm/loki-ack/Chart.yaml
+++ b/gitops/argocd/charts/krm/loki-ack/Chart.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+---
+apiVersion: v2
+name: loki-ack
+description: A Helm chart for Loki AWS resources using ACK
+type: application
+version: 0.1.0
+appVersion: "2.9.4"

--- a/gitops/argocd/charts/krm/loki-ack/templates/iam.yaml
+++ b/gitops/argocd/charts/krm/loki-ack/templates/iam.yaml
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: iam.services.k8s.aws/v1alpha1
+kind: Policy
+metadata:
+  name: {{ .Values.clusterName }}-loki-s3-policy
+  namespace: {{ .Values.namespace }}
+spec:
+  name: {{ .Values.clusterName }}-loki-s3-policy
+  description: "Bucket permissions for Loki"
+  policyDocument: |
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "s3:ListBucket",
+            "s3:GetObject",
+            "s3:DeleteObject",
+            "s3:PutObject"
+          ],
+          "Resource": [
+            "arn:aws:s3:::{{ .Values.clusterName }}-loki-admin",
+            "arn:aws:s3:::{{ .Values.clusterName }}-loki-admin/*",
+            "arn:aws:s3:::{{ .Values.clusterName }}-loki-chunks",
+            "arn:aws:s3:::{{ .Values.clusterName }}-loki-chunks/*",
+            "arn:aws:s3:::{{ .Values.clusterName }}-loki-ruler",
+            "arn:aws:s3:::{{ .Values.clusterName }}-loki-ruler/*"
+          ]
+        }
+        {{- if .Values.enableKMS }},
+        {
+          "Effect": "Allow",
+          "Action": [
+            "kms:Encrypt",
+            "kms:Decrypt",
+            "kms:GenerateDataKey*"
+          ],
+          "Resource": [
+            "arn:aws:kms:{{ .Values.region }}:{{ .Values.accountID }}:key/*"
+          ]
+        }
+        {{- end }}
+      ]
+    }
+  tags:
+    {{- range $key, $value := .Values.tags }}
+    - key: {{ $key }}
+      value: {{ $value }}
+    {{- end }}
+
+{{- if .Values.enableKMS }}
+---
+apiVersion: iam.services.k8s.aws/v1alpha1
+kind: Policy
+metadata:
+  name: {{ .Values.clusterName }}-loki-kms-policy
+  namespace: {{ .Values.namespace }}
+spec:
+  name: {{ .Values.clusterName }}-loki-kms-policy
+  description: "KMS permissions for Loki"
+  policyDocument: |
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "kms:Encrypt",
+            "kms:Decrypt",
+            "kms:GenerateDataKey*"
+          ],
+          "Resource": [
+            "arn:aws:kms:{{ .Values.region }}:{{ .Values.accountID }}:key/*"
+          ]
+        }
+      ]
+    }
+  tags:
+    {{- range $key, $value := .Values.tags }}
+    - key: {{ $key }}
+      value: {{ $value }}
+    {{- end }}
+{{- end }}
+
+---
+apiVersion: iam.services.k8s.aws/v1alpha1
+kind: Role
+metadata:
+  name: {{ .Values.clusterName }}-loki-role
+  namespace: {{ .Values.namespace }}
+spec:
+  name: {{ .Values.clusterName }}-loki-role
+  assumeRolePolicyDocument: |
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "pods.eks.amazonaws.com"
+          },
+          "Action": [
+            "sts:AssumeRole",
+            "sts:TagSession"
+          ]
+        }
+      ]
+    }
+  policyRefs:
+    - from:
+        name: {{ .Values.clusterName }}-loki-s3-policy
+    {{- if .Values.enableKMS }}
+    - from:
+        name: {{ .Values.clusterName }}-loki-kms-policy
+    {{- end }}
+  tags:
+    {{- range $key, $value := .Values.tags }}
+    - key: {{ $key }}
+      value: {{ $value }}
+    {{- end }}

--- a/gitops/argocd/charts/krm/loki-ack/templates/kms.yaml
+++ b/gitops/argocd/charts/krm/loki-ack/templates/kms.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.enableKMS }}
+---
+apiVersion: kms.services.k8s.aws/v1alpha1
+kind: Key
+metadata:
+  name: {{ .Values.clusterName }}-loki-key
+  namespace: {{ .Values.namespace }}
+spec:
+  description: "KMS for Loki"
+  enableKeyRotation: true
+  tags:
+    {{- range $key, $value := .Values.tags }}
+    - key: {{ $key }}
+      value: {{ $value }}
+    {{- end }}
+
+---
+apiVersion: kms.services.k8s.aws/v1alpha1
+kind: Alias
+metadata:
+  name: {{ .Values.clusterName }}-loki-alias
+  namespace: {{ .Values.namespace }}
+spec:
+  aliasName: alias/{{ .Values.clusterName }}-loki
+  targetKeyRef:
+    from:
+      name: {{ .Values.clusterName }}-loki-key
+{{- end }}

--- a/gitops/argocd/charts/krm/loki-ack/templates/pod-identity.yaml
+++ b/gitops/argocd/charts/krm/loki-ack/templates/pod-identity.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: eks.services.k8s.aws/v1alpha1
+kind: PodIdentityAssociation
+metadata:
+  name: {{ .Values.clusterName }}-loki-pod-identity
+  namespace: {{ .Values.namespace }}
+spec:
+  clusterName: {{ .Values.clusterName }}
+  namespace: {{ .Values.namespace }}
+  serviceAccount: {{ .Values.serviceAccount }}
+  roleRef:
+    from:
+      name: {{ .Values.clusterName }}-loki-role
+  tags:
+    {{- range $key, $value := .Values.tags }}
+    {{ $key }}: {{ $value }}
+    {{- end }}

--- a/gitops/argocd/charts/krm/loki-ack/templates/s3.yaml
+++ b/gitops/argocd/charts/krm/loki-ack/templates/s3.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+{{- $region := .Values.region -}}
+{{- $clusterName := .Values.clusterName -}}
+{{- $tags := .Values.tags -}}
+{{- range $bucket := (list "admin" "chunks" "ruler") }}
+---
+apiVersion: s3.services.k8s.aws/v1alpha1
+kind: Bucket
+metadata:
+  name: {{ $clusterName }}-loki-{{ $bucket }}
+  namespace: {{ $.Values.namespace }}
+spec:
+  name: {{ $clusterName }}-loki-{{ $bucket }}
+  tagging:
+    tagSet:
+    {{- range $key, $value := $tags }}
+    - key: {{ $key }}
+      value: {{ $value }}
+    {{- end }}
+{{- end }}

--- a/gitops/argocd/charts/krm/loki-ack/values.yaml
+++ b/gitops/argocd/charts/krm/loki-ack/values.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+clusterName: portefaix-aws-staging
+namespace: logging
+serviceAccount: loki
+region: eu-west-1
+accountID: "123456789012" # Update with your AWS Account ID
+
+enableKMS: false
+
+tags:
+  portefaix.xyz/version: v0.54.0
+  Made-By: ACK


### PR DESCRIPTION
This PR introduces a new Helm chart `loki-ack` in `gitops/argocd/charts/krm/` that provides the AWS infrastructure resources for Loki using AWS Controllers for Kubernetes (ACK).

Key components:
- **S3 Buckets**: `admin`, `chunks`, and `ruler` buckets configured with tags.
- **IAM Resources**:
    - `Policy`: `loki-s3-policy` and optionally `loki-kms-policy`.
    - `Role`: `loki-role` with trust relationship for EKS Pod Identity and references to the policies.
- **EKS Pod Identity**: `PodIdentityAssociation` to link the IAM role with the Loki service account.
- **KMS Support**: Optional KMS key and alias creation, with corresponding policy adjustments.

The resources are prefixed with the cluster name and support tagging as per the project's standards. Manifests use ACK `Refs` to reference other Kubernetes-managed AWS resources.

---
*PR created automatically by Jules for task [15248916363087924369](https://jules.google.com/task/15248916363087924369) started by @nlamirault*