### PR TITLE
feat(tempo): add ACK and Crossplane configuration

### DIFF
--- a/gitops/argocd/charts/logging/loki/templates/ack-policy.yaml
+++ b/gitops/argocd/charts/logging/loki/templates/ack-policy.yaml
@@ -18,17 +18,24 @@ spec:
         {
           "Effect": "Allow",
           "Action": [
-            "s3:ListBucket",
+            "s3:ListBucket"
+          ],
+          "Resource": [
+            "arn:aws:s3:::{{ .Values.ack.clusterName }}-loki-admin",
+            "arn:aws:s3:::{{ .Values.ack.clusterName }}-loki-chunks",
+            "arn:aws:s3:::{{ .Values.ack.clusterName }}-loki-ruler"
+          ]
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
             "s3:GetObject",
             "s3:DeleteObject",
             "s3:PutObject"
           ],
           "Resource": [
-            "arn:aws:s3:::{{ .Values.ack.clusterName }}-loki-admin",
             "arn:aws:s3:::{{ .Values.ack.clusterName }}-loki-admin/*",
-            "arn:aws:s3:::{{ .Values.ack.clusterName }}-loki-chunks",
             "arn:aws:s3:::{{ .Values.ack.clusterName }}-loki-chunks/*",
-            "arn:aws:s3:::{{ .Values.ack.clusterName }}-loki-ruler",
             "arn:aws:s3:::{{ .Values.ack.clusterName }}-loki-ruler/*"
           ]
         }

--- a/gitops/argocd/charts/logging/loki/templates/ack-s3.yaml
+++ b/gitops/argocd/charts/logging/loki/templates/ack-s3.yaml
@@ -16,6 +16,6 @@ spec:
   name: {{ $clusterName }}-loki-{{ $bucket }}
   tagging:
     tagSet:
-    {{- toYaml $.Values.ack.tags | nindent 6 }}
+    {{- toYaml $tags | nindent 6 }}
 {{- end }}
 {{- end }}

--- a/gitops/argocd/charts/logging/loki/values-aws-staging.yaml
+++ b/gitops/argocd/charts/logging/loki/values-aws-staging.yaml
@@ -21,5 +21,7 @@ ack:
   clusterName: portefaix-staging-eks
   serviceAccount: loki
   tags:
-    portefaix/krm: aws-controllers-k8s
-    portefaix/environment: staging
+    - key: portefaix/krm
+      value: aws-controllers-k8s
+    - key: portefaix/environment
+      value: staging

--- a/gitops/argocd/charts/logging/loki/values-aws-staging.yaml
+++ b/gitops/argocd/charts/logging/loki/values-aws-staging.yaml
@@ -21,7 +21,5 @@ ack:
   clusterName: portefaix-staging-eks
   serviceAccount: loki
   tags:
-    - key: portefaix/krm
-      value: aws-controllers-k8s
-    - key: portefaix/environment
-      value: staging
+    portefaix/krm: aws-controllers-k8s
+    portefaix/environment: staging

--- a/gitops/argocd/charts/tracing/tempo/templates/ack-podidentity.yaml
+++ b/gitops/argocd/charts/tracing/tempo/templates/ack-podidentity.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if .Values.ack.enabled -}}
+---
+apiVersion: eks.services.k8s.aws/v1alpha1
+kind: PodIdentityAssociation
+metadata:
+  name: {{ .Values.ack.clusterName }}-tempo
+  namespace: {{ .Release.Namespace }}
+spec:
+  clusterName: {{ .Values.ack.clusterName }}
+  namespace: {{ .Release.Namespace }}
+  serviceAccount: {{ .Values.ack.serviceAccount }}
+  roleRef:
+    name: {{ .Values.ack.clusterName }}-tempo
+  tags:
+    {{- toYaml .Values.ack.tags | nindent 4 }}
+{{- end }}

--- a/gitops/argocd/charts/tracing/tempo/templates/ack-policy.yaml
+++ b/gitops/argocd/charts/tracing/tempo/templates/ack-policy.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if .Values.ack.enabled -}}
+---
+apiVersion: iam.services.k8s.aws/v1alpha1
+kind: Policy
+metadata:
+  name: {{ .Values.ack.clusterName }}-tempo-s3
+  namespace: {{ .Release.Namespace }}
+spec:
+  name: {{ .Values.ack.clusterName }}-tempo-s3
+  description: "Bucket permissions for Tempo"
+  policyDocument: |
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "s3:ListBucket",
+            "s3:GetObject",
+            "s3:DeleteObject",
+            "s3:PutObject"
+          ],
+          "Resource": [
+            "arn:aws:s3:::{{ .Values.ack.clusterName }}-tempo-traces",
+            "arn:aws:s3:::{{ .Values.ack.clusterName }}-tempo-traces/*",
+            "arn:aws:s3:::{{ .Values.ack.clusterName }}-tempo-admin",
+            "arn:aws:s3:::{{ .Values.ack.clusterName }}-tempo-admin/*",
+            "arn:aws:s3:::{{ .Values.ack.clusterName }}-tempo-wal",
+            "arn:aws:s3:::{{ .Values.ack.clusterName }}-tempo-wal/*"
+          ]
+        }
+      ]
+    }
+  tags:
+    {{- toYaml .Values.ack.tags | nindent 4 }}
+{{- end }}

--- a/gitops/argocd/charts/tracing/tempo/templates/ack-policy.yaml
+++ b/gitops/argocd/charts/tracing/tempo/templates/ack-policy.yaml
@@ -18,17 +18,24 @@ spec:
         {
           "Effect": "Allow",
           "Action": [
-            "s3:ListBucket",
+            "s3:ListBucket"
+          ],
+          "Resource": [
+            "arn:aws:s3:::{{ .Values.ack.clusterName }}-tempo-traces",
+            "arn:aws:s3:::{{ .Values.ack.clusterName }}-tempo-admin",
+            "arn:aws:s3:::{{ .Values.ack.clusterName }}-tempo-wal"
+          ]
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
             "s3:GetObject",
             "s3:DeleteObject",
             "s3:PutObject"
           ],
           "Resource": [
-            "arn:aws:s3:::{{ .Values.ack.clusterName }}-tempo-traces",
             "arn:aws:s3:::{{ .Values.ack.clusterName }}-tempo-traces/*",
-            "arn:aws:s3:::{{ .Values.ack.clusterName }}-tempo-admin",
             "arn:aws:s3:::{{ .Values.ack.clusterName }}-tempo-admin/*",
-            "arn:aws:s3:::{{ .Values.ack.clusterName }}-tempo-wal",
             "arn:aws:s3:::{{ .Values.ack.clusterName }}-tempo-wal/*"
           ]
         }

--- a/gitops/argocd/charts/tracing/tempo/templates/ack-role.yaml
+++ b/gitops/argocd/charts/tracing/tempo/templates/ack-role.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if .Values.ack.enabled -}}
+---
+apiVersion: iam.services.k8s.aws/v1alpha1
+kind: Role
+metadata:
+  name: {{ .Values.ack.clusterName }}-tempo
+  namespace: {{ .Release.Namespace }}
+spec:
+  name: {{ .Values.ack.clusterName }}-tempo
+  assumeRolePolicyDocument: |
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "pods.eks.amazonaws.com"
+          },
+          "Action": [
+            "sts:AssumeRole",
+            "sts:TagSession"
+          ]
+        }
+      ]
+    }
+  policyRefs:
+    - name: {{ .Values.ack.clusterName }}-tempo-s3
+  tags:
+    {{- toYaml .Values.ack.tags | nindent 4 }}
+{{- end }}

--- a/gitops/argocd/charts/tracing/tempo/templates/ack-s3.yaml
+++ b/gitops/argocd/charts/tracing/tempo/templates/ack-s3.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if .Values.ack.enabled -}}
+{{- $region := .Values.ack.region -}}
+{{- $clusterName := .Values.ack.clusterName -}}
+{{- $tags := .Values.ack.tags -}}
+{{- range $bucket := (list "traces" "admin" "wal") }}
+---
+apiVersion: s3.services.k8s.aws/v1alpha1
+kind: Bucket
+metadata:
+  name: {{ $clusterName }}-tempo-{{ $bucket }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  name: {{ $clusterName }}-tempo-{{ $bucket }}
+  tagging:
+    tagSet:
+    {{- toYaml $.Values.ack.tags | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/gitops/argocd/charts/tracing/tempo/templates/ack-s3.yaml
+++ b/gitops/argocd/charts/tracing/tempo/templates/ack-s3.yaml
@@ -16,6 +16,6 @@ spec:
   name: {{ $clusterName }}-tempo-{{ $bucket }}
   tagging:
     tagSet:
-    {{- toYaml $.Values.ack.tags | nindent 6 }}
+    {{- toYaml $tags | nindent 6 }}
 {{- end }}
 {{- end }}

--- a/gitops/argocd/charts/tracing/tempo/templates/crossplane-cloudflare-r2-lifecycle.yaml
+++ b/gitops/argocd/charts/tracing/tempo/templates/crossplane-cloudflare-r2-lifecycle.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if .Values.crossplaneCloudflare.enabled -}}
+{{- $accountId := .Values.crossplaneCloudflare.accountId -}}
+{{- $retention := mul .Values.crossplaneCloudflare.retention 86400 -}}
+{{- range $bucket := (list "traces" "admin" "wal") }}
+---
+apiVersion: r2.cloudflare.crossplane.io/v1alpha1
+kind: R2BucketLifecycle
+metadata:
+  name: {{ $.Release.Name }}-tempo-{{ $bucket }}-lifecycle
+  namespace: {{ $.Release.Namespace }}
+spec:
+  forProvider:
+    accountId: {{ $accountId | quote }}
+    bucketName: {{ $.Values.crossplaneCloudflare.bucketName }}-tempo-{{ $bucket }}
+    rules:
+      - id: "expire-tempo-{{ $bucket }}"
+        enabled: true
+        deleteObjectsTransition:
+          condition:
+            maxAge: {{ $retention }}
+            type: "Age"
+  providerConfigRef:
+    name: default
+{{- end }}
+{{- end }}

--- a/gitops/argocd/charts/tracing/tempo/templates/crossplane-cloudflare-r2.yaml
+++ b/gitops/argocd/charts/tracing/tempo/templates/crossplane-cloudflare-r2.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if .Values.crossplaneCloudflare.enabled -}}
+{{- $accountId := .Values.crossplaneCloudflare.accountId -}}
+{{- $region := .Values.crossplaneCloudflare.region -}}
+{{- range $bucket := (list "traces" "admin" "wal") }}
+---
+apiVersion: r2.cloudflare.crossplane.io/v1alpha1
+kind: R2Bucket
+metadata:
+  name: {{ $.Release.Name }}-tempo-{{ $bucket }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  forProvider:
+    accountId: {{ $accountId | quote }}
+    name: {{ $.Values.crossplaneCloudflare.bucketName }}-tempo-{{ $bucket }}
+    location: {{ $region }}
+  providerConfigRef:
+    name: default
+{{- end }}
+{{- end }}

--- a/gitops/argocd/charts/tracing/tempo/values-aws-staging.yaml
+++ b/gitops/argocd/charts/tracing/tempo/values-aws-staging.yaml
@@ -10,7 +10,7 @@ tempo-distributed:
       requests:
         cpu: 100m
         memory: 128Mi
-  
+
   # Note: Actual S3 configuration is now managed via ACK.
   # We still need to configure the Tempo components to point to the buckets.
   # This part is complex because tempo-distributed chart structure is different from loki.
@@ -27,7 +27,5 @@ ack:
   clusterName: portefaix-staging-eks
   serviceAccount: tempo
   tags:
-    - key: portefaix/krm
-      value: aws-controllers-k8s
-    - key: portefaix/environment
-      value: staging
+    portefaix/krm: aws-controllers-k8s
+    portefaix/environment: staging

--- a/gitops/argocd/charts/tracing/tempo/values-aws-staging.yaml
+++ b/gitops/argocd/charts/tracing/tempo/values-aws-staging.yaml
@@ -2,43 +2,32 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-tempo:
-  tempo:
+tempo-distributed:
+  ingester:
     resources:
       limits:
-        # cpu: 200m
         memory: 256Mi
       requests:
         cpu: 100m
         memory: 128Mi
-    storage:
-      trace:
-        backend: s3
-        s3:
-          bucket: portefaix-aws-staging-tempo
-          endpoint: s3.dualstack.us-east-2.amazonaws.com # api endpoint
-          # access_key: ...                                 # optional. access key when using static credentials.
-          # secret_key: ...                                 # optional. secret key when using static credentials.
-          insecure: false
-          # receivers:
-          #   jaeger:
-          #     protocols:
-          #       grpc:
-          #         endpoint: 0.0.0.0:14250
-          #       thrift_binary:
-          #         endpoint: 0.0.0.0:6832
-          #       thrift_compact:
-          #         endpoint: 0.0.0.0:6831
-          #       thrift_http:
-          #         endpoint: 0.0.0.0:14268
-          #   opencensus:
-          #   otlp:
-          #     protocols:
-          #       grpc:
-          #         endpoint: "0.0.0.0:4317"
-          #       http:
-          #         endpoint: "0.0.0.0:4318"
+  
+  # Note: Actual S3 configuration is now managed via ACK.
+  # We still need to configure the Tempo components to point to the buckets.
+  # This part is complex because tempo-distributed chart structure is different from loki.
+  # Assuming standard S3 config structure for now.
+  storage:
+    trace:
+      backend: s3
+      s3:
+        bucket: portefaix-staging-eks-tempo-traces
+        # endpoint: s3.dualstack.us-east-2.amazonaws.com # Not needed with ACK PodIdentity
 
-  serviceAccount:
-    annotations:
-      eks.amazonaws.com/role-arn: "arn:aws:iam::447241706233:role/tempo"
+ack:
+  enabled: true
+  clusterName: portefaix-staging-eks
+  serviceAccount: tempo
+  tags:
+    - key: portefaix/krm
+      value: aws-controllers-k8s
+    - key: portefaix/environment
+      value: staging

--- a/gitops/argocd/charts/tracing/tempo/values-aws-staging.yaml
+++ b/gitops/argocd/charts/tracing/tempo/values-aws-staging.yaml
@@ -27,5 +27,7 @@ ack:
   clusterName: portefaix-staging-eks
   serviceAccount: tempo
   tags:
-    portefaix/krm: aws-controllers-k8s
-    portefaix/environment: staging
+    - key: portefaix/krm
+      value: aws-controllers-k8s
+    - key: portefaix/environment
+      value: staging

--- a/gitops/argocd/charts/tracing/tempo/values-talos-homelab.yaml
+++ b/gitops/argocd/charts/tracing/tempo/values-talos-homelab.yaml
@@ -117,11 +117,11 @@ tempo-distributed:
   storage:
     trace:
       block:
-      # -- The supported block versions are specified here https://grafana.com/docs/tempo/latest/configuration/parquet/
-      version: vParquet4
-      backend: s3
+        # -- The supported block versions are specified here https://grafana.com/docs/tempo/latest/configuration/parquet/
+        version: vParquet4
+        backend: s3
       s3:
-        bucket: portefaix-homelab-traces-chunks
+        bucket: portefaix-talos-homelab-tempo-traces
         endpoint: ${AWS_S3_ENDPOINT_NO_HTTPS}
         access_key: ${AWS_ACCESS_KEY_ID}
         secret_key: ${AWS_SECRET_ACCESS_KEY}
@@ -171,3 +171,13 @@ tempo-distributed:
   metaMonitoring:
     serviceMonitor:
       clusterLabel: portefaix-talos-homelab
+
+crossplaneCloudflare:
+  enabled: true
+  accountId: ""
+  region: enam
+  retention: 10
+  bucketName: portefaix-talos-homelab
+  tags:
+    portefaix.xyz/krm: crossplane
+    portefaix.xyz/environment: homelab

--- a/gitops/argocd/charts/tracing/tempo/values.yaml
+++ b/gitops/argocd/charts/tracing/tempo/values.yaml
@@ -204,3 +204,18 @@ tempo-mixin:
       allowCrossNamespaceImport: true
       matchLabels:
         grafana.com/dashboards: portefaix
+
+ack:
+  enabled: false
+  clusterName: ""
+  serviceAccount: ""
+  region: ""
+  tags: {}
+
+crossplaneCloudflare:
+  enabled: false
+  accountId: ""
+  region: enam
+  retention: 10
+  bucketName: ""
+  tags: {}


### PR DESCRIPTION
## Summary

- Add ACK templates for Tempo (podidentity, policy, role, s3)
- Add Crossplane templates for Tempo (R2 bucket, lifecycle)
- Update Tempo values for AWS staging and Talos homelab to use new infrastructure patterns