### PR TITLE
feat(pyroscope): add ACK and Crossplane Cloudflare R2 support

### DIFF
--- a/gitops/argocd/charts/profiling/pyroscope/templates/ack-podidentity.yaml
+++ b/gitops/argocd/charts/profiling/pyroscope/templates/ack-podidentity.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if .Values.ack.enabled -}}
+---
+apiVersion: eks.services.k8s.aws/v1alpha1
+kind: PodIdentityAssociation
+metadata:
+  name: {{ .Values.ack.clusterName }}-pyroscope
+  namespace: {{ .Release.Namespace }}
+spec:
+  clusterName: {{ .Values.ack.clusterName }}
+  namespace: {{ .Release.Namespace }}
+  serviceAccount: {{ .Values.ack.serviceAccount }}
+  roleRef:
+    name: {{ .Values.ack.clusterName }}-pyroscope
+  tags:
+    {{- toYaml .Values.ack.tags | nindent 4 }}
+{{- end }}

--- a/gitops/argocd/charts/profiling/pyroscope/templates/ack-policy.yaml
+++ b/gitops/argocd/charts/profiling/pyroscope/templates/ack-policy.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if .Values.ack.enabled -}}
+---
+apiVersion: iam.services.k8s.aws/v1alpha1
+kind: Policy
+metadata:
+  name: {{ .Values.ack.clusterName }}-pyroscope-s3
+  namespace: {{ .Release.Namespace }}
+spec:
+  name: {{ .Values.ack.clusterName }}-pyroscope-s3
+  description: "Bucket permissions for Pyroscope"
+  policyDocument: |
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "s3:ListBucket"
+          ],
+          "Resource": [
+            "arn:aws:s3:::{{ .Values.ack.clusterName }}-pyroscope-chunks"
+          ]
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "s3:GetObject",
+            "s3:DeleteObject",
+            "s3:PutObject"
+          ],
+          "Resource": [
+            "arn:aws:s3:::{{ .Values.ack.clusterName }}-pyroscope-chunks/*"
+          ]
+        }
+      ]
+    }
+  tags:
+    {{- toYaml .Values.ack.tags | nindent 4 }}
+{{- end }}

--- a/gitops/argocd/charts/profiling/pyroscope/templates/ack-role.yaml
+++ b/gitops/argocd/charts/profiling/pyroscope/templates/ack-role.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if .Values.ack.enabled -}}
+---
+apiVersion: iam.services.k8s.aws/v1alpha1
+kind: Role
+metadata:
+  name: {{ .Values.ack.clusterName }}-pyroscope
+  namespace: {{ .Release.Namespace }}
+spec:
+  name: {{ .Values.ack.clusterName }}-pyroscope
+  assumeRolePolicyDocument: |
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "pods.eks.amazonaws.com"
+          },
+          "Action": [
+            "sts:AssumeRole",
+            "sts:TagSession"
+          ]
+        }
+      ]
+    }
+  policyRefs:
+    - name: {{ .Values.ack.clusterName }}-pyroscope-s3
+  tags:
+    {{- toYaml .Values.ack.tags | nindent 4 }}
+{{- end }}

--- a/gitops/argocd/charts/profiling/pyroscope/templates/ack-s3.yaml
+++ b/gitops/argocd/charts/profiling/pyroscope/templates/ack-s3.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if .Values.ack.enabled -}}
+{{- $region := .Values.ack.region -}}
+{{- $clusterName := .Values.ack.clusterName -}}
+{{- $tags := .Values.ack.tags -}}
+{{- range $bucket := (list "chunks") }}
+---
+apiVersion: s3.services.k8s.aws/v1alpha1
+kind: Bucket
+metadata:
+  name: {{ $clusterName }}-pyroscope-{{ $bucket }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  name: {{ $clusterName }}-pyroscope-{{ $bucket }}
+  tagging:
+    tagSet:
+    {{- toYaml $tags | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/gitops/argocd/charts/profiling/pyroscope/templates/crossplane-cloudflare-r2-lifecycle.yaml
+++ b/gitops/argocd/charts/profiling/pyroscope/templates/crossplane-cloudflare-r2-lifecycle.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if .Values.crossplaneCloudflare.enabled -}}
+{{- $accountId := .Values.crossplaneCloudflare.accountId -}}
+{{- $retention := mul .Values.crossplaneCloudflare.retention 86400 -}}
+{{- range $bucket := (list "chunks") }}
+---
+apiVersion: r2.cloudflare.crossplane.io/v1alpha1
+kind: R2BucketLifecycle
+metadata:
+  name: {{ $.Release.Name }}-pyroscope-{{ $bucket }}-lifecycle
+  namespace: {{ $.Release.Namespace }}
+spec:
+  forProvider:
+    accountId: {{ $accountId | quote }}
+    bucketName: {{ $.Values.crossplaneCloudflare.bucketName }}-pyroscope-{{ $bucket }}
+    rules:
+      - id: "expire-pyroscope-{{ $bucket }}"
+        enabled: true
+        deleteObjectsTransition:
+          condition:
+            maxAge: {{ $retention }}
+            type: "Age"
+  providerConfigRef:
+    name: default
+{{- end }}
+{{- end }}

--- a/gitops/argocd/charts/profiling/pyroscope/templates/crossplane-cloudflare-r2.yaml
+++ b/gitops/argocd/charts/profiling/pyroscope/templates/crossplane-cloudflare-r2.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if .Values.crossplaneCloudflare.enabled -}}
+{{- $accountId := .Values.crossplaneCloudflare.accountId -}}
+{{- $region := .Values.crossplaneCloudflare.region -}}
+{{- range $bucket := (list "chunks") }}
+---
+apiVersion: r2.cloudflare.crossplane.io/v1alpha1
+kind: R2Bucket
+metadata:
+  name: {{ $.Release.Name }}-pyroscope-{{ $bucket }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  forProvider:
+    accountId: {{ $accountId | quote }}
+    name: {{ $.Values.crossplaneCloudflare.bucketName }}-pyroscope-{{ $bucket }}
+    location: {{ $region }}
+  providerConfigRef:
+    name: default
+{{- end }}
+{{- end }}

--- a/gitops/argocd/charts/profiling/pyroscope/values-aws-staging.yaml
+++ b/gitops/argocd/charts/profiling/pyroscope/values-aws-staging.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+pyroscope:
+  pyroscope:
+    config: |
+      storage:
+        backend: s3
+        s3:
+          bucket_name: portefaix-staging-eks-pyroscope-chunks
+          endpoint: ${AWS_S3_ENDPOINT}
+          access_key_id: ${AWS_ACCESS_KEY_ID}
+          secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+          insecure: false
+
+ack:
+  enabled: true
+  clusterName: portefaix-staging-eks
+  serviceAccount: pyroscope
+  tags:
+    - key: portefaix/krm
+      value: aws-controllers-k8s
+    - key: portefaix/environment
+      value: staging

--- a/gitops/argocd/charts/profiling/pyroscope/values-talos-homelab.yaml
+++ b/gitops/argocd/charts/profiling/pyroscope/values-talos-homelab.yaml
@@ -131,8 +131,18 @@ pyroscope:
       storage:
         backend: s3
         s3:
-          bucket_name: portefaix-homelab-profiles-chunks
+          bucket_name: portefaix-talos-homelab-pyroscope-chunks
           endpoint: ${AWS_S3_ENDPOINT_NO_HTTPS}
           access_key_id: ${AWS_ACCESS_KEY_ID}
           secret_access_key: ${AWS_SECRET_ACCESS_KEY}
           insecure: false
+
+crossplaneCloudflare:
+  enabled: true
+  accountId: ""
+  region: enam
+  retention: 10
+  bucketName: portefaix-talos-homelab
+  tags:
+    portefaix.xyz/krm: crossplane
+    portefaix.xyz/environment: homelab

--- a/gitops/argocd/charts/profiling/pyroscope/values.yaml
+++ b/gitops/argocd/charts/profiling/pyroscope/values.yaml
@@ -46,3 +46,18 @@ pyroscope-mixin:
       allowCrossNamespaceImport: true
       matchLabels:
         grafana.com/dashboards: portefaix
+
+ack:
+  enabled: false
+  region: eu-west-1
+  clusterName: ""
+  serviceAccount: pyroscope
+  tags: []
+
+crossplaneCloudflare:
+  enabled: false
+  accountId: ""
+  region: enam
+  retention: 10
+  bucketName: ""
+  tags: {}


### PR DESCRIPTION
## Summary

- Add ACK templates (S3 bucket, IAM role/policy, EKS Pod Identity Association) for Pyroscope on AWS staging
- Add Crossplane Cloudflare R2 templates (R2Bucket + R2BucketLifecycle with configurable retention) for Pyroscope on Talos homelab