### PR TITLE
feat(loki): add Crossplane exoscale SOS support

### DIFF
--- a/gitops/argocd/charts/logging/loki/Chart.yaml
+++ b/gitops/argocd/charts/logging/loki/Chart.yaml
@@ -10,7 +10,7 @@ appVersion: 1.0.0
 dependencies:
 - name: loki
   repository: oci://ghcr.io/grafana-community/helm-charts
-  version: 17.3.1
+  version: 18.4.1
 # - name: loki-mixin
 #   repository: oci://ghcr.io/portefaix/charts
 #   version: 1.4.0

--- a/gitops/argocd/charts/logging/loki/templates/ack-podidentity.yaml
+++ b/gitops/argocd/charts/logging/loki/templates/ack-podidentity.yaml
@@ -6,6 +6,11 @@
 apiVersion: eks.services.k8s.aws/v1alpha1
 kind: PodIdentityAssociation
 metadata:
+  labels:
+    {{- include "loki.labels" (index $.Subcharts "loki") | nindent 4 }}
+    app.kubernetes.io/component: iam
+    portefaix.xyz/krm: ack
+    portefaix.xyz/version: v1.3.0
   name: {{ .Values.ack.clusterName }}-loki
   namespace: {{ .Release.Namespace }}
 spec:

--- a/gitops/argocd/charts/logging/loki/templates/ack-policy.yaml
+++ b/gitops/argocd/charts/logging/loki/templates/ack-policy.yaml
@@ -6,6 +6,11 @@
 apiVersion: iam.services.k8s.aws/v1alpha1
 kind: Policy
 metadata:
+  labels:
+    {{- include "loki.labels" (index $.Subcharts "loki") | nindent 4 }}
+    app.kubernetes.io/component: iam
+    portefaix.xyz/krm: ack
+    portefaix.xyz/version: v1.3.0
   name: {{ .Values.ack.clusterName }}-loki-s3
   namespace: {{ .Release.Namespace }}
 spec:

--- a/gitops/argocd/charts/logging/loki/templates/ack-role.yaml
+++ b/gitops/argocd/charts/logging/loki/templates/ack-role.yaml
@@ -6,6 +6,11 @@
 apiVersion: iam.services.k8s.aws/v1alpha1
 kind: Role
 metadata:
+  labels:
+    {{- include "loki.labels" (index $.Subcharts "loki") | nindent 4 }}
+    app.kubernetes.io/component: iam
+    portefaix.xyz/krm: ack
+    portefaix.xyz/version: v1.3.0
   name: {{ .Values.ack.clusterName }}-loki
   namespace: {{ .Release.Namespace }}
 spec:

--- a/gitops/argocd/charts/logging/loki/templates/ack-s3.yaml
+++ b/gitops/argocd/charts/logging/loki/templates/ack-s3.yaml
@@ -10,6 +10,11 @@
 apiVersion: s3.services.k8s.aws/v1alpha1
 kind: Bucket
 metadata:
+  labels:
+    {{- include "loki.labels" (index $.Subcharts "loki") | nindent 4 }}
+    app.kubernetes.io/component: bucket
+    portefaix.xyz/krm: ack
+    portefaix.xyz/version: v1.3.0
   name: {{ $clusterName }}-loki-{{ $bucket }}
   namespace: {{ $.Release.Namespace }}
 spec:

--- a/gitops/argocd/charts/logging/loki/templates/cloudflare.yaml
+++ b/gitops/argocd/charts/logging/loki/templates/cloudflare.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
+{{ if .Values.crossplaneCloudflare.enabled -}}
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
@@ -29,3 +30,4 @@ spec:
   - secretKey: AWS_S3_ENDPOINT
     remoteRef:
       key: AWS_S3_ENDPOINT
+{{- end }}

--- a/gitops/argocd/charts/logging/loki/templates/crossplane-cloudflare-r2-lifecycle.yaml
+++ b/gitops/argocd/charts/logging/loki/templates/crossplane-cloudflare-r2-lifecycle.yaml
@@ -9,6 +9,11 @@
 apiVersion: r2.cloudflare.crossplane.io/v1alpha1
 kind: R2BucketLifecycle
 metadata:
+  labels:
+    {{- include "loki.labels" (index $.Subcharts "loki") | nindent 4 }}
+    app.kubernetes.io/component: bucket
+    portefaix.xyz/krm: crossplane
+    portefaix.xyz/version: v1.3.0
   name: {{ $.Release.Name }}-loki-{{ $bucket }}-lifecycle
   namespace: {{ $.Release.Namespace }}
 spec:

--- a/gitops/argocd/charts/logging/loki/templates/crossplane-cloudflare-r2.yaml
+++ b/gitops/argocd/charts/logging/loki/templates/crossplane-cloudflare-r2.yaml
@@ -9,6 +9,11 @@
 apiVersion: r2.cloudflare.crossplane.io/v1alpha1
 kind: R2Bucket
 metadata:
+  labels:
+    {{- include "loki.labels" (index $.Subcharts "loki") | nindent 4 }}
+    app.kubernetes.io/component: bucket
+    portefaix.xyz/krm: cloudflare
+    portefaix.xyz/version: v1.3.0
   name: {{ $.Release.Name }}-loki-{{ $bucket }}
   namespace: {{ $.Release.Namespace }}
 spec:

--- a/gitops/argocd/charts/logging/loki/templates/crossplane-exoscale-iam.yaml
+++ b/gitops/argocd/charts/logging/loki/templates/crossplane-exoscale-iam.yaml
@@ -2,10 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {{ if .Values.crossplaneExoscale.enabled -}}
+{{- $providerName := required "crossplaneExoscale.provider.name is required when crossplaneExoscale.enabled is true" .Values.crossplaneExoscale.provider.name -}}
 ---
-apiVersion: iam.exoscale.exoscale.ch/v1alpha1
+apiVersion: iam.exoscale.m.exoscale.ch/v1alpha1
 kind: IAMRole
 metadata:
+  labels:
+    {{- include "loki.labels" (index $.Subcharts "loki") | nindent 4 }}
+    app.kubernetes.io/component: iam
+    portefaix.xyz/krm: crossplane
+    portefaix.xyz/version: v1.3.0
   name: {{ .Release.Name }}-loki
   namespace: {{ .Release.Namespace }}
 spec:
@@ -20,12 +26,18 @@ spec:
           type: allow
   providerConfigRef:
     kind: ClusterProviderConfig
-    name: {{ .Values.crossplaneExoscale.provider.name }}
+    name: {{ $providerName }}
 ---
-apiVersion: iam.exoscale.exoscale.ch/v1alpha1
+apiVersion: iam.exoscale.m.exoscale.ch/v1alpha1
 kind: IAMAPIKey
 metadata:
+  labels:
+    {{- include "loki.labels" (index $.Subcharts "loki") | nindent 4 }}
+    app.kubernetes.io/component: iam
+    portefaix.xyz/krm: crossplane
+    portefaix.xyz/version: v1.3.0
   name: {{ .Release.Name }}-loki
+  namespace: {{ .Release.Namespace }}
 spec:
   forProvider:
     name: {{ .Release.Name }}-loki
@@ -36,5 +48,5 @@ spec:
     name: {{ .Release.Name }}-exoscale-iam-credentials
   providerConfigRef:
     kind: ClusterProviderConfig
-    name: {{ .Values.crossplaneExoscale.provider.name }}
+    name: {{ $providerName }}
 {{- end }}

--- a/gitops/argocd/charts/logging/loki/templates/crossplane-exoscale-iam.yaml
+++ b/gitops/argocd/charts/logging/loki/templates/crossplane-exoscale-iam.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if .Values.crossplaneExoscale.enabled -}}
+---
+apiVersion: iam.exoscale.exoscale.ch/v1alpha1
+kind: IAMRole
+metadata:
+  name: {{ .Release.Name }}-loki
+  namespace: {{ .Release.Namespace }}
+spec:
+  forProvider:
+    name: {{ .Release.Name }}-loki
+    description: "IAM role for Loki SOS buckets"
+    editable: false
+    policy:
+      defaultServiceStrategy: deny
+      services:
+        sos:
+          type: allow
+  providerConfigRef:
+    kind: ClusterProviderConfig
+    name: {{ .Values.crossplaneExoscale.provider.name }}
+---
+apiVersion: iam.exoscale.exoscale.ch/v1alpha1
+kind: IAMAPIKey
+metadata:
+  name: {{ .Release.Name }}-loki
+spec:
+  forProvider:
+    name: {{ .Release.Name }}-loki
+    roleIdRef:
+      name: {{ .Release.Name }}-loki
+  writeConnectionSecretToRef:
+    namespace: {{ .Release.Namespace }}
+    name: {{ .Release.Name }}-exoscale-iam-credentials
+  providerConfigRef:
+    kind: ClusterProviderConfig
+    name: {{ .Values.crossplaneExoscale.provider.name }}
+{{- end }}

--- a/gitops/argocd/charts/logging/loki/templates/crossplane-exoscale-sos.yaml
+++ b/gitops/argocd/charts/logging/loki/templates/crossplane-exoscale-sos.yaml
@@ -2,39 +2,47 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {{ if .Values.crossplaneExoscale.enabled -}}
+{{- $bucketName := required "crossplaneExoscale.bucketName is required when crossplaneExoscale.enabled is true" .Values.crossplaneExoscale.bucketName -}}
+{{- $providerName := required "crossplaneExoscale.provider.name is required when crossplaneExoscale.enabled is true" .Values.crossplaneExoscale.provider.name -}}
 {{- range $bucket := (list "admin" "chunks" "ruler") }}
 ---
-apiVersion: sos.sos.exoscale.ch/v1alpha1
+apiVersion: sos.sos.m.exoscale.ch/v1alpha1
 kind: Bucket
 metadata:
-  name: {{ $.Values.crossplaneExoscale.bucketName }}-loki-{{ $bucket }}
+  labels:
+    {{- include "loki.labels" (index $.Subcharts "loki") | nindent 4 }}
+    app.kubernetes.io/component: bucket
+    portefaix.xyz/krm: crossplane
+    portefaix.xyz/version: v1.3.0
+  name: {{ $bucketName }}-loki-{{ $bucket }}
   namespace: {{ $.Release.Namespace }}
   annotations:
-    crossplane.io/external-name: {{ $.Values.crossplaneExoscale.bucketName }}-loki-{{ $bucket }}
+    crossplane.io/external-name: {{ $bucketName }}-loki-{{ $bucket }}
 spec:
   forProvider: {}
   providerConfigRef:
     kind: ClusterProviderConfig
-    name: {{ $.Values.crossplaneExoscale.provider.name }}
+    name: {{ $providerName }}
 ---
 apiVersion: sos.sos.m.exoscale.ch/v1alpha1
 kind: BucketVersioning
 metadata:
-  annotations:
-    meta.upbound.io/example-id: sos/v1alpha1/bucketversioning
   labels:
-    testing.upbound.io/example-name: versioning_example
-  name: {{ $.Values.crossplaneExoscale.bucketName }}-loki-{{ $bucket }}
+    {{- include "loki.labels" (index $.Subcharts "loki") | nindent 4 }}
+    app.kubernetes.io/component: bucket
+    portefaix.xyz/krm: crossplane
+    portefaix.xyz/version: v1.3.0
+  name: {{ $bucketName }}-loki-{{ $bucket }}
   namespace: {{ $.Release.Namespace }}
 spec:
   forProvider:
     bucketRef:
-      name: {{ $.Values.crossplaneExoscale.bucketName }}-loki-{{ $bucket }}
+      name: {{ $bucketName }}-loki-{{ $bucket }}
       namespace: {{ $.Release.Namespace }}
     versioningConfiguration:
     - status: Enabled
   providerConfigRef:
     kind: ClusterProviderConfig
-    name: {{ $.Values.crossplaneExoscale.provider.name }}
+    name: {{ $providerName }}
 {{- end }}
 {{- end }}

--- a/gitops/argocd/charts/logging/loki/templates/crossplane-exoscale-sos.yaml
+++ b/gitops/argocd/charts/logging/loki/templates/crossplane-exoscale-sos.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if .Values.crossplaneExoscale.enabled -}}
+{{- range $bucket := (list "admin" "chunks" "ruler") }}
+---
+apiVersion: sos.sos.exoscale.ch/v1alpha1
+kind: Bucket
+metadata:
+  name: {{ $.Values.crossplaneExoscale.bucketName }}-loki-{{ $bucket }}
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+    crossplane.io/external-name: {{ $.Values.crossplaneExoscale.bucketName }}-loki-{{ $bucket }}
+spec:
+  forProvider: {}
+  providerConfigRef:
+    kind: ClusterProviderConfig
+    name: {{ $.Values.crossplaneExoscale.provider.name }}
+---
+apiVersion: sos.sos.m.exoscale.ch/v1alpha1
+kind: BucketVersioning
+metadata:
+  annotations:
+    meta.upbound.io/example-id: sos/v1alpha1/bucketversioning
+  labels:
+    testing.upbound.io/example-name: versioning_example
+  name: {{ $.Values.crossplaneExoscale.bucketName }}-loki-{{ $bucket }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  forProvider:
+    bucketRef:
+      name: {{ $.Values.crossplaneExoscale.bucketName }}-loki-{{ $bucket }}
+      namespace: {{ $.Release.Namespace }}
+    versioningConfiguration:
+    - status: Enabled
+  providerConfigRef:
+    kind: ClusterProviderConfig
+    name: {{ $.Values.crossplaneExoscale.provider.name }}
+{{- end }}
+{{- end }}

--- a/gitops/argocd/charts/logging/loki/templates/exoscale.yaml
+++ b/gitops/argocd/charts/logging/loki/templates/exoscale.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
+{{ if .Values.crossplaneExoscale.enabled -}}
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
@@ -29,3 +30,4 @@ spec:
   - secretKey: AWS_S3_ENDPOINT
     remoteRef:
       key: AWS_S3_ENDPOINT
+{{- end }}

--- a/gitops/argocd/charts/logging/loki/templates/exoscale.yaml
+++ b/gitops/argocd/charts/logging/loki/templates/exoscale.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  labels:
+    {{- include "loki.labels" (index $.Subcharts "loki") | nindent 4 }}
+    app.kubernetes.io/component: loki-credentials
+    portefaix.xyz/version: v1.3.0
+  name: loki-exoscale-credentials
+  namespace: {{ .Release.Namespace }}
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: akeyless
+  target:
+    name: loki-exoscale-credentials
+    creationPolicy: Owner
+  data:
+  - secretKey: AWS_ACCESS_KEY_ID
+    remoteRef:
+      key: AWS_ACCESS_KEY_ID
+  - secretKey: AWS_SECRET_ACCESS_KEY
+    remoteRef:
+      key: AWS_SECRET_ACCESS_KEY
+  - secretKey: AWS_S3_ENDPOINT
+    remoteRef:
+      key: AWS_S3_ENDPOINT

--- a/gitops/argocd/charts/logging/loki/values-exoscale-dev.yaml
+++ b/gitops/argocd/charts/logging/loki/values-exoscale-dev.yaml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+loki:
+  clusterLabelOverride: portefaix-exoscale-dev
+
+  loki:
+    storage:
+      bucketNames:
+        admin: portefaix-dev-loki-admin
+        chunks: portefaix-dev-loki-chunks
+        ruler: portefaix-dev-loki-ruler
+      type: s3
+      s3:
+        s3: null
+        endpoint: ${AWS_S3_ENDPOINT}
+        region: ch-dk-2
+        access_key_id: ${AWS_ACCESS_KEY_ID}
+        secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+        s3ForcePathStyle: true
+        insecure: false
+        http_config: {}
+
+  ingester:
+    extraEnvFrom:
+    - secretRef:
+        name: loki-exoscale-credentials
+
+  distributor:
+    extraEnvFrom:
+    - secretRef:
+        name: loki-exoscale-credentials
+
+  querier:
+    extraEnvFrom:
+    - secretRef:
+        name: loki-exoscale-credentials
+
+  compactor:
+    extraEnvFrom:
+    - secretRef:
+        name: loki-exoscale-credentials
+
+crossplaneExoscale:
+  enabled: true
+  provider:
+    name: portefaix-exoscale-dev
+  zone: ch-dk-2
+  bucketName: portefaix-dev
+  tags:
+    portefaix.xyz/krm: crossplane
+    portefaix.xyz/environment: dev

--- a/gitops/argocd/charts/logging/loki/values-exoscale-dev.yaml
+++ b/gitops/argocd/charts/logging/loki/values-exoscale-dev.yaml
@@ -48,6 +48,3 @@ crossplaneExoscale:
     name: portefaix-exoscale-dev
   zone: ch-dk-2
   bucketName: portefaix-dev
-  tags:
-    portefaix.xyz/krm: crossplane
-    portefaix.xyz/environment: dev

--- a/gitops/argocd/charts/logging/loki/values.yaml
+++ b/gitops/argocd/charts/logging/loki/values.yaml
@@ -265,3 +265,11 @@ crossplaneCloudflare:
   region: enam
   retention: 10
   tags: {}
+
+crossplaneExoscale:
+  enabled: false
+  provider:
+    name: ""
+  zone: ch-dk-2
+  bucketName: ""
+  tags: {}

--- a/gitops/argocd/charts/logging/loki/values.yaml
+++ b/gitops/argocd/charts/logging/loki/values.yaml
@@ -57,6 +57,9 @@ loki:
       - -log.format=json
       - -log.level=info
 
+  commonLabels:
+    portefaix.xyz/version: v1.3.0
+
   loki:
     auth_enabled: false
 
@@ -272,4 +275,3 @@ crossplaneExoscale:
     name: ""
   zone: ch-dk-2
   bucketName: ""
-  tags: {}


### PR DESCRIPTION
## Summary

- Creates Bucket and BucketVersioning CRs for admin/chunks/ruler buckets using [provider-exoscale-sos](https://github.com/exoscale/provider-exoscale-sos)
- creates IAMRole (SOS allow policy) and IAMAPIKey writing scoped credentials to a k8s Secret 
- ExternalSecret reading SOS credentials from Akeyless (mirrors `cloudflare.yaml` pattern)