### PR TITLE
feat(loki): add Crossplane Scaleway Object Storage support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ helm-flux-template: guard-CHART guard-CLOUD guard-ENV ## Install Helm chart (CHA
 	@echo -e "$(OK_COLOR)[$(APP)] Build Helm chart ${CHART}:${ENV}$(NO_COLOR)" >&2
 	@DEBUG=$(DEBUG) . hack/scripts/chart-fluxcd.sh $(CHART) \
 		&& export TMPFILE=$$(./hack/scripts/flux-helm.sh "$(CHART)" "$(CLOUD)/$(ENV)") \
-		&& helm template --debug $${CHART_NAME} $${CHART_REPO_NAME}/$${CHART_NAME} --namespace $${CHART_NAMESPACE} -f $${TMPFILE}
+		&& helm template $(DEBUG) $${CHART_NAME} $${CHART_REPO_NAME}/$${CHART_NAME} --namespace $${CHART_NAMESPACE} -f $${TMPFILE}
 
 .PHONY: helm-flux-install
 helm-flux-install: guard-CHART guard-CLOUD guard-ENV kubernetes-check-context ## Install Helm chart (CHART=xxx CLOUD=xxx ENV=xxx)
@@ -159,7 +159,7 @@ helm-argo-template: guard-CHART guard-CLOUD guard-ENV ## Template Helm chart (CH
 		&& export NAMESPACE=$$(basename $$(dirname $(CHART))) \
 		&& rm -fr charts Chart.lock \
 		&& helm dependency build >&2 \
-		&& helm template portefaix-$${CHART_NAME} . --debug --namespace $${NAMESPACE} -f ./values.yaml -f "./values-$(CLOUD)-$(ENV).yaml" --api-versions=monitoring.coreos.com/v1 \
+		&& helm template portefaix-$${CHART_NAME} . $(DEBUG) --namespace $${NAMESPACE} -f ./values.yaml -f "./values-$(CLOUD)-$(ENV).yaml" --api-versions=monitoring.coreos.com/v1 \
 		&& rm -fr Chart.lock charts \
 		&& popd > /dev/null
 
@@ -171,7 +171,7 @@ helm-argo-template-crds: guard-CHART guard-CLOUD guard-ENV ## Template Helm char
 		&& export NAMESPACE=$$(basename $$(dirname $(CHART))) \
 		&& rm -fr charts Chart.lock \
 		&& helm dependency build >&2 \
-		&& helm template portefaix-$${CHART_NAME} . --debug --include-crds --namespace $${NAMESPACE} -f ./values.yaml -f "./values-$(CLOUD)-$(ENV).yaml" --api-versions=monitoring.coreos.com/v1 \
+		&& helm template portefaix-$${CHART_NAME} . $(DEBUG) --include-crds --namespace $${NAMESPACE} -f ./values.yaml -f "./values-$(CLOUD)-$(ENV).yaml" --api-versions=monitoring.coreos.com/v1 \
 		&& rm -fr Chart.lock charts \
 		&& popd > /dev/null
 
@@ -183,7 +183,7 @@ helm-argo-install: guard-CHART guard-CLOUD guard-ENV kubernetes-check-context ##
 		&& export NAMESPACE=$$(basename $$(dirname $(CHART))) \
 		&& rm -fr charts Chart.lock \
 		&& helm dependency build >&2 \
-		&& helm upgrade --install portefaix-$${CHART_NAME} . --debug --namespace $${NAMESPACE} --create-namespace -f ./values.yaml -f "./values-$(CLOUD)-$(ENV).yaml" \
+		&& helm upgrade --install portefaix-$${CHART_NAME} . $(DEBUG) --namespace $${NAMESPACE} --create-namespace -f ./values.yaml -f "./values-$(CLOUD)-$(ENV).yaml" \
 		&& rm -fr Chart.lock charts \
 		&& popd > /dev/null
 
@@ -203,7 +203,7 @@ helm-argo-kubescape: guard-CHART guard-CLOUD guard-ENV ## Install Helm chart (CH
 		&& export NAMESPACE=$$(basename $$(dirname $(CHART))) \
 		&& rm -fr charts Chart.lock \
 		&& helm dependency build >&2 \
-		&& helm template portefaix . --debug --namespace $${NAMESPACE} -f ./values.yaml -f "./values-$(CLOUD)-$(ENV).yaml" --api-versions=monitoring.coreos.com/v1 > manifests.yaml \
+		&& helm template portefaix . $(DEBUG) --namespace $${NAMESPACE} -f ./values.yaml -f "./values-$(CLOUD)-$(ENV).yaml" --api-versions=monitoring.coreos.com/v1 > manifests.yaml \
 		&& kubescape scan manifests.yaml
 
 # .PHONY: helm-argo-kubescape

--- a/gitops/argocd/charts/logging/loki/templates/crossplane-scaleway-iam.yaml
+++ b/gitops/argocd/charts/logging/loki/templates/crossplane-scaleway-iam.yaml
@@ -42,25 +42,3 @@ spec:
       - ObjectStorageFullAccess
   providerConfigRef:
     name: {{ $providerName }}
----
-apiVersion: iam.scaleway.m.upbound.io/v1alpha1
-kind: ApiKey
-metadata:
-  labels:
-    {{- include "loki.labels" (index $.Subcharts "loki") | nindent 4 }}
-    app.kubernetes.io/component: iam
-    portefaix.xyz/krm: crossplane
-    portefaix.xyz/version: v1.3.0
-  name: {{ .Release.Name }}-loki
-  namespace: {{ .Release.Namespace }}
-spec:
-  forProvider:
-    description: {{ .Release.Name }}-loki
-    applicationIdRef:
-      name: {{ .Release.Name }}-loki
-  writeConnectionSecretToRef:
-    namespace: {{ .Release.Namespace }}
-    name: {{ .Release.Name }}-scaleway-iam-credentials
-  providerConfigRef:
-    name: {{ $providerName }}
-{{- end }}

--- a/gitops/argocd/charts/logging/loki/templates/crossplane-scaleway-iam.yaml
+++ b/gitops/argocd/charts/logging/loki/templates/crossplane-scaleway-iam.yaml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if .Values.crossplaneScaleway.enabled -}}
+{{- $providerName := required "crossplaneScaleway.provider.name is required when crossplaneScaleway.enabled is true" .Values.crossplaneScaleway.provider.name -}}
+---
+apiVersion: iam.scaleway.m.upbound.io/v1alpha1
+kind: Application
+metadata:
+  labels:
+    {{- include "loki.labels" (index $.Subcharts "loki") | nindent 4 }}
+    app.kubernetes.io/component: iam
+    portefaix.xyz/krm: crossplane
+    portefaix.xyz/version: v1.3.0
+  name: {{ .Release.Name }}-loki
+  namespace: {{ .Release.Namespace }}
+spec:
+  forProvider:
+    name: {{ .Release.Name }}-loki
+    description: "IAM application for Loki Object Storage"
+  providerConfigRef:
+    name: {{ $providerName }}
+---
+apiVersion: iam.scaleway.m.upbound.io/v1alpha1
+kind: Policy
+metadata:
+  labels:
+    {{- include "loki.labels" (index $.Subcharts "loki") | nindent 4 }}
+    app.kubernetes.io/component: iam
+    portefaix.xyz/krm: crossplane
+    portefaix.xyz/version: v1.3.0
+  name: {{ .Release.Name }}-loki
+  namespace: {{ .Release.Namespace }}
+spec:
+  forProvider:
+    name: {{ .Release.Name }}-loki
+    description: "Policy for Loki Object Storage access"
+    applicationIdRef:
+      name: {{ .Release.Name }}-loki
+    rule:
+    - permissionSetNames:
+      - ObjectStorageFullAccess
+  providerConfigRef:
+    name: {{ $providerName }}
+---
+apiVersion: iam.scaleway.m.upbound.io/v1alpha1
+kind: ApiKey
+metadata:
+  labels:
+    {{- include "loki.labels" (index $.Subcharts "loki") | nindent 4 }}
+    app.kubernetes.io/component: iam
+    portefaix.xyz/krm: crossplane
+    portefaix.xyz/version: v1.3.0
+  name: {{ .Release.Name }}-loki
+  namespace: {{ .Release.Namespace }}
+spec:
+  forProvider:
+    description: {{ .Release.Name }}-loki
+    applicationIdRef:
+      name: {{ .Release.Name }}-loki
+  writeConnectionSecretToRef:
+    namespace: {{ .Release.Namespace }}
+    name: {{ .Release.Name }}-scaleway-iam-credentials
+  providerConfigRef:
+    name: {{ $providerName }}
+{{- end }}

--- a/gitops/argocd/charts/logging/loki/templates/crossplane-scaleway-object.yaml
+++ b/gitops/argocd/charts/logging/loki/templates/crossplane-scaleway-object.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if .Values.crossplaneScaleway.enabled -}}
+{{- $bucketName := required "crossplaneScaleway.bucketName is required when crossplaneScaleway.enabled is true" .Values.crossplaneScaleway.bucketName -}}
+{{- $providerName := required "crossplaneScaleway.provider.name is required when crossplaneScaleway.enabled is true" .Values.crossplaneScaleway.provider.name -}}
+{{- $region := required "crossplaneScaleway.region is required when crossplaneScaleway.enabled is true" .Values.crossplaneScaleway.region -}}
+{{- range $bucket := (list "admin" "chunks" "ruler") }}
+---
+apiVersion: object.scaleway.m.upbound.io/v1alpha1
+kind: Bucket
+metadata:
+  labels:
+    {{- include "loki.labels" (index $.Subcharts "loki") | nindent 4 }}
+    app.kubernetes.io/component: bucket
+    portefaix.xyz/krm: crossplane
+    portefaix.xyz/version: v1.3.0
+  name: {{ $bucketName }}-loki-{{ $bucket }}
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+    crossplane.io/external-name: {{ $bucketName }}-loki-{{ $bucket }}
+spec:
+  forProvider:
+    name: {{ $bucketName }}-loki-{{ $bucket }}
+    region: {{ $region }}
+    versioning:
+    - enabled: true
+  providerConfigRef:
+    name: {{ $providerName }}
+{{- end }}
+{{- end }}

--- a/gitops/argocd/charts/logging/loki/templates/scaleway.yaml
+++ b/gitops/argocd/charts/logging/loki/templates/scaleway.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if .Values.crossplaneScaleway.enabled -}}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  labels:
+    {{- include "loki.labels" (index $.Subcharts "loki") | nindent 4 }}
+    app.kubernetes.io/component: loki-credentials
+    portefaix.xyz/version: v1.3.0
+  name: loki-scaleway-credentials
+  namespace: {{ .Release.Namespace }}
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: akeyless
+  target:
+    name: loki-scaleway-credentials
+    creationPolicy: Owner
+  data:
+  - secretKey: AWS_ACCESS_KEY_ID
+    remoteRef:
+      key: AWS_ACCESS_KEY_ID
+  - secretKey: AWS_SECRET_ACCESS_KEY
+    remoteRef:
+      key: AWS_SECRET_ACCESS_KEY
+  - secretKey: AWS_S3_ENDPOINT
+    remoteRef:
+      key: AWS_S3_ENDPOINT
+{{- end }}

--- a/gitops/argocd/charts/logging/loki/values-aws-staging.yaml
+++ b/gitops/argocd/charts/logging/loki/values-aws-staging.yaml
@@ -16,6 +16,22 @@ loki:
         endpoint: ${AWS_S3_ENDPOINT}
 
 
+  indexGateway:
+    resources:
+      limits:
+        memory: 600Mi
+      requests:
+        cpu: 60m
+        memory: 200Mi
+
+  ruler:
+    resources:
+      limits:
+        memory: 600Mi
+      requests:
+        cpu: 60m
+        memory: 200Mi
+
 ack:
   enabled: true
   clusterName: portefaix-staging-eks

--- a/gitops/argocd/charts/logging/loki/values-exoscale-dev.yaml
+++ b/gitops/argocd/charts/logging/loki/values-exoscale-dev.yaml
@@ -26,21 +26,67 @@ loki:
     extraEnvFrom:
     - secretRef:
         name: loki-exoscale-credentials
+    resources:
+      limits:
+        memory: 600Mi
+      requests:
+        cpu: 60m
+        memory: 200Mi
 
   distributor:
     extraEnvFrom:
     - secretRef:
         name: loki-exoscale-credentials
+    resources:
+      limits:
+        memory: 600Mi
+      requests:
+        cpu: 60m
+        memory: 200Mi
 
   querier:
     extraEnvFrom:
     - secretRef:
         name: loki-exoscale-credentials
+    resources:
+      limits:
+        memory: 600Mi
+      requests:
+        cpu: 60m
+        memory: 200Mi
 
   compactor:
     extraEnvFrom:
     - secretRef:
         name: loki-exoscale-credentials
+    resources:
+      limits:
+        memory: 600Mi
+      requests:
+        cpu: 60m
+        memory: 200Mi
+
+  indexGateway:
+    extraEnvFrom:
+    - secretRef:
+        name: loki-exoscale-credentials
+    resources:
+      limits:
+        memory: 600Mi
+      requests:
+        cpu: 60m
+        memory: 200Mi
+
+  ruler:
+    extraEnvFrom:
+    - secretRef:
+        name: loki-exoscale-credentials
+    resources:
+      limits:
+        memory: 600Mi
+      requests:
+        cpu: 60m
+        memory: 200Mi
 
 crossplaneExoscale:
   enabled: true

--- a/gitops/argocd/charts/logging/loki/values-scw-sandbox.yaml
+++ b/gitops/argocd/charts/logging/loki/values-scw-sandbox.yaml
@@ -26,21 +26,67 @@ loki:
     extraEnvFrom:
     - secretRef:
         name: loki-scaleway-credentials
+    resources:
+      limits:
+        memory: 600Mi
+      requests:
+        cpu: 60m
+        memory: 200Mi
 
   distributor:
     extraEnvFrom:
     - secretRef:
         name: loki-scaleway-credentials
+    resources:
+      limits:
+        memory: 600Mi
+      requests:
+        cpu: 60m
+        memory: 200Mi
 
   querier:
     extraEnvFrom:
     - secretRef:
         name: loki-scaleway-credentials
+    resources:
+      limits:
+        memory: 600Mi
+      requests:
+        cpu: 60m
+        memory: 200Mi
 
   compactor:
     extraEnvFrom:
     - secretRef:
         name: loki-scaleway-credentials
+    resources:
+      limits:
+        memory: 600Mi
+      requests:
+        cpu: 60m
+        memory: 200Mi
+
+  indexGateway:
+    extraEnvFrom:
+    - secretRef:
+        name: loki-scaleway-credentials
+    resources:
+      limits:
+        memory: 600Mi
+      requests:
+        cpu: 60m
+        memory: 200Mi
+
+  ruler:
+    extraEnvFrom:
+    - secretRef:
+        name: loki-scaleway-credentials
+    resources:
+      limits:
+        memory: 600Mi
+      requests:
+        cpu: 60m
+        memory: 200Mi
 
 crossplaneScaleway:
   enabled: true

--- a/gitops/argocd/charts/logging/loki/values-scw-sandbox.yaml
+++ b/gitops/argocd/charts/logging/loki/values-scw-sandbox.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+loki:
+  clusterLabelOverride: portefaix-scw-sandbox
+
+  loki:
+    storage:
+      bucketNames:
+        admin: portefaix-sandbox-loki-admin
+        chunks: portefaix-sandbox-loki-chunks
+        ruler: portefaix-sandbox-loki-ruler
+      type: s3
+      s3:
+        s3: null
+        endpoint: ${AWS_S3_ENDPOINT}
+        region: fr-par
+        access_key_id: ${AWS_ACCESS_KEY_ID}
+        secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+        s3ForcePathStyle: true
+        insecure: false
+        http_config: {}
+
+  ingester:
+    extraEnvFrom:
+    - secretRef:
+        name: loki-scaleway-credentials
+
+  distributor:
+    extraEnvFrom:
+    - secretRef:
+        name: loki-scaleway-credentials
+
+  querier:
+    extraEnvFrom:
+    - secretRef:
+        name: loki-scaleway-credentials
+
+  compactor:
+    extraEnvFrom:
+    - secretRef:
+        name: loki-scaleway-credentials
+
+crossplaneScaleway:
+  enabled: true
+  provider:
+    name: portefaix-scw-sandbox
+  region: fr-par
+  bucketName: portefaix-sandbox

--- a/gitops/argocd/charts/logging/loki/values-talos-homelab.yaml
+++ b/gitops/argocd/charts/logging/loki/values-talos-homelab.yaml
@@ -160,6 +160,28 @@ loki:
           size: 300Mi
           storageClass: local-path
 
+  indexGateway:
+    extraEnvFrom:
+    - secretRef:
+        name: loki-cloudflare-credentials
+    resources:
+      limits:
+        memory: 600Mi
+      requests:
+        cpu: 60m
+        memory: 200Mi
+
+  ruler:
+    extraEnvFrom:
+    - secretRef:
+        name: loki-cloudflare-credentials
+    resources:
+      limits:
+        memory: 600Mi
+      requests:
+        cpu: 60m
+        memory: 200Mi
+
   query_range:
     align_queries_with_step: true
     parallelise_shardable_queries: false

--- a/gitops/argocd/charts/logging/loki/values.yaml
+++ b/gitops/argocd/charts/logging/loki/values.yaml
@@ -275,3 +275,10 @@ crossplaneExoscale:
     name: ""
   zone: ch-dk-2
   bucketName: ""
+
+crossplaneScaleway:
+  enabled: false
+  provider:
+    name: ""
+  region: fr-par
+  bucketName: ""


### PR DESCRIPTION
## Summary

- Add Scaleway Object Storage buckets (admin/chunks/ruler) via Crossplane `object.scaleway.m.upbound.io/v1alpha1`, with versioning inline in bucket spec
- Add IAM resources (Application + Policy + ApiKey) using `iam.scaleway.m.upbound.io/v1alpha1` — Scaleway separates identity from permissions unlike Exoscale
- Add ExternalSecret syncing S3 credentials from Akeyless into `loki-scaleway-credentials` for Loki components
- Add `values-scw-sandbox.yaml` for the Scaleway sandbox environment (mirrors `values-exoscale-dev.yaml` pattern from #7119)
- Add `crossplaneScaleway` defaults block to `values.yaml`